### PR TITLE
Add neuron_expl.md for Neuron Explanation project

### DIFF
--- a/content/project/neuron_expl.md
+++ b/content/project/neuron_expl.md
@@ -1,0 +1,35 @@
++++
+date= ""
+description = ""
+short_description = "Understanding what knowledge AI learn and where it stores in its neurons."
+title = "Neuron Explanations"
+project_id = ""
+picture = "cce_splash.png"
+external_link = ""
+include_participants_portraits = true
+sort_position = 1
+[[participants]] 
+    name = "leilani"
+    is_member = true
+    id = "leilani"
+[[participants]]
+    name = "Biagio 'Mattia' La Rosa"
+    is_member = true
+    id = "mattia"
+[[participants]]
+    name = "Rishika Srinivas"
+    is_member = true
+    id = "rishika_s"
+[[participants]]
+    name = "Arnav Kartikeya"
+    is_member = true
+    id = "arnav_k"
++++ The Neuron Explanation project aims to understand what deep neural networks (CNN, LLMs) learn during the training process by analyzing what individual neurons are able to recognize in terms of concepts (e.g., cat, building, etc). Specifically, we aim to achieve this goal by associating logical rules (e.g., (Cat OR Dog) AND NOT person)) to each neuron that express the (spatial) alignment between neurons activations and concept locations. These rules are usually extracted by combining search algorithms, clustering algorithms and statistical analysis of neurons activation.
+
+## Previous Publications
+[1] "Towards a fuller understanding of neurons with Clustered Compositional Explanations". Biagio La Rosa, Leilani Gilpin, and Roberto Capobianco. NeurIPS 2023 (<a href="https://proceedings.neurips.cc/paper_files/paper/2023/hash/debd0ae2083160397a22a4a8831c7230-Abstract-Conference.html">LINK</a>)
+
+## Related Readings
+[1] Mu, Jesse, and Jacob Andreas. "Compositional explanations of neurons." Advances in Neural Information Processing Systems 33 (2020): 17153-17163. (<a href="https://arxiv.org/abs/2006.14032">LINK</a>)
+
+[2] Bau, David, et al. "Network dissection: Quantifying interpretability of deep visual representations." Proceedings of the IEEE conference on computer vision and pattern recognition. 2017. (<a href="https://openaccess.thecvf.com/content_cvpr_2017/html/Bau_Network_Dissection_Quantifying_CVPR_2017_paper.html">LINK</a>)


### PR DESCRIPTION
The Neuron Explanation project aims to analyze what individual neurons recognize during training by associating logical rules to neuron activations. It includes previous publications and related readings.