### PR TITLE
Add auditor hall of fame

### DIFF
--- a/data/auditor_hall_of_fame.yaml
+++ b/data/auditor_hall_of_fame.yaml
@@ -1,0 +1,8 @@
+entries:
+  - quarter: "Fall 2025"
+    name: "First Last"
+    recognition: "Inducted into the Auditor Hall of Fame."
+
+  - quarter: "Fall 2025"
+    name: "First Last"
+    recognition: "Inducted into the Auditor Hall of Fame."

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>Categories on AIEA Lab</title>
-    <link>https://aiea-lab.github.io/categories/</link>
-    <description>Recent content in Categories on AIEA Lab</description>
-    <generator>Hugo</generator>
-    <language>en</language>
-    <copyright>&amp;copy; AIEA Lab, 2023 </copyright>
-    <atom:link href="https://aiea-lab.github.io/categories/index.xml" rel="self" type="application/rss+xml" />
-  </channel>
+	<channel>
+		<title>Categories on AIEA Lab</title>
+		<link>https://aiea-lab.github.io/categories/</link>
+		<description>Recent content in Categories on AIEA Lab</description>
+		<generator>Hugo</generator>
+		<language>en</language>
+		
+		
+		
+			<copyright>&amp;copy; AIEA Lab, 2023 </copyright>
+		
+		
+			<atom:link href="https://aiea-lab.github.io/categories/index.xml" rel="self" type="application/rss+xml" />
+	</channel>
 </rss>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta name="generator" content="Hugo 0.146.7">
+	<meta name="generator" content="Hugo 0.162.0">
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -349,6 +349,154 @@
         
 
             <h3 class="article-title" itemprop="name">
+                <a href="https://aiea-lab.github.io/publication/guaranteed-optimal-compositional-explanations-2025/" itemprop="url">Guaranteed Optimal Compositional Explanations for Neurons</a>
+            </h3>
+
+            <div class="pub-authors" itemprop="author">
+                
+  
+  <div itemprop="author">
+      
+          
+              
+<span class="author-name">
+    
+        La Rosa, Biagio
+    
+</span>,
+          
+          
+              
+<span class="author-name">
+    
+        Gilpin, Leilani H
+    
+</span>
+          
+      
+  </div>
+
+
+            </div>
+
+            <div class="pub-publication">
+                
+                    arXiv preprint arXiv:2511.20934
+                
+                
+                <div itemprop="datePublished">
+                    
+                        November, 2025
+                    
+                </div>
+            </div>
+
+            <div class="pub-links">
+                
+
+
+
+<a class="btn btn-primary btn-outline btn-xs" href="https://aiea-lab.github.io/publication/guaranteed-optimal-compositional-explanations-2025/">Details</a>
+
+
+<a class="btn btn-primary btn-outline btn-xs" href="https://arxiv.org/pdf/2511.20934">PDF</a>
+
+
+
+
+
+
+
+
+
+            </div>
+
+        </div>
+    </div>
+</div>
+
+                
+                    <div class="pub-list-item" itemscope itemtype="http://schema.org/CreativeWork">
+    <div class="row">
+        
+        <div class="col-md-12">
+        
+
+            <h3 class="article-title" itemprop="name">
+                <a href="https://aiea-lab.github.io/publication/open-vocabulary-compositional-explanations-2025/" itemprop="url">Open Vocabulary Compositional Explanations for Neuron Alignment</a>
+            </h3>
+
+            <div class="pub-authors" itemprop="author">
+                
+  
+  <div itemprop="author">
+      
+          
+              
+<span class="author-name">
+    
+        La Rosa, Biagio
+    
+</span>,
+          
+          
+              
+<span class="author-name">
+    
+        Gilpin, Leilani H
+    
+</span>
+          
+      
+  </div>
+
+
+            </div>
+
+            <div class="pub-publication">
+                
+                    arXiv preprint arXiv:2511.20931
+                
+                
+                <div itemprop="datePublished">
+                    
+                        November, 2025
+                    
+                </div>
+            </div>
+
+            <div class="pub-links">
+                
+
+
+
+<a class="btn btn-primary btn-outline btn-xs" href="https://aiea-lab.github.io/publication/open-vocabulary-compositional-explanations-2025/">Details</a>
+
+
+<a class="btn btn-primary btn-outline btn-xs" href="https://arxiv.org/pdf/2511.20931">PDF</a>
+
+
+
+
+
+
+
+
+
+            </div>
+
+        </div>
+    </div>
+</div>
+
+                
+                    <div class="pub-list-item" itemscope itemtype="http://schema.org/CreativeWork">
+    <div class="row">
+        
+        <div class="col-md-12">
+        
+
+            <h3 class="article-title" itemprop="name">
                 <a href="https://aiea-lab.github.io/publication/follow-my-lead-logical-fallacy-classification-with-knowledge-augmented-llms-2025/" itemprop="url">Follow My Lead: Logical Fallacy Classification with Knowledge-Augmented LLMs</a>
             </h3>
 
@@ -569,203 +717,6 @@
 
 
 <a class="btn btn-primary btn-outline btn-xs" href="https://arxiv.org/pdf/2509.23971?">PDF</a>
-
-
-
-
-
-
-
-
-
-            </div>
-
-        </div>
-    </div>
-</div>
-
-                
-                    <div class="pub-list-item" itemscope itemtype="http://schema.org/CreativeWork">
-    <div class="row">
-        
-        <div class="col-md-12">
-        
-
-            <h3 class="article-title" itemprop="name">
-                <a href="https://aiea-lab.github.io/publication/autonomous-driving-with-spiking-neural-networks-2024/" itemprop="url">Autonomous driving with spiking neural networks</a>
-            </h3>
-
-            <div class="pub-authors" itemprop="author">
-                
-  
-  <div itemprop="author">
-      
-          
-              
-<span class="author-name">
-    
-        Zhu, Rui-Jie
-    
-</span>,
-          
-              
-<span class="author-name">
-    
-        Wang, Ziqing
-    
-</span>,
-          
-              
-<span class="author-name">
-    
-        Gilpin, Leilani
-    
-</span>,
-          
-          
-              
-<span class="author-name">
-    
-        Eshraghian, Jason
-    
-</span>
-          
-      
-  </div>
-
-
-            </div>
-
-            <div class="pub-publication">
-                
-                    Advances in Neural Information Processing Systems
-                
-                
-                <div itemprop="datePublished">
-                    
-                        December, 2024
-                    
-                </div>
-            </div>
-
-            <div class="pub-links">
-                
-
-
-
-<a class="btn btn-primary btn-outline btn-xs" href="https://aiea-lab.github.io/publication/autonomous-driving-with-spiking-neural-networks-2024/">Details</a>
-
-
-<a class="btn btn-primary btn-outline btn-xs" href="https://proceedings.neurips.cc/paper_files/paper/2024/file/f7344147dbd1607deac3a7e5f33a23aa-Paper-Conference.pdf">PDF</a>
-
-
-
-
-
-
-
-
-
-            </div>
-
-        </div>
-    </div>
-</div>
-
-                
-                    <div class="pub-list-item" itemscope itemtype="http://schema.org/CreativeWork">
-    <div class="row">
-        
-        <div class="col-md-12">
-        
-
-            <h3 class="article-title" itemprop="name">
-                <a href="https://aiea-lab.github.io/publication/right-this-way-can-vlms-guide-us-to-see-more-to-answer-questions-2024/" itemprop="url">Right this way: Can VLMs Guide Us to See More to Answer Questions?</a>
-            </h3>
-
-            <div class="pub-authors" itemprop="author">
-                
-  
-  <div itemprop="author">
-      
-          
-              
-<span class="author-name">
-    
-        Liu, Li
-    
-</span>,
-          
-              
-<span class="author-name">
-    
-        Yang, Diji
-    
-</span>,
-          
-              
-<span class="author-name">
-    
-        Zhong, Sijia
-    
-</span>,
-          
-              
-<span class="author-name">
-    
-        Tholeti, Kalyana Suma Sree
-    
-</span>,
-          
-              
-<span class="author-name">
-    
-        Ding, Lei
-    
-</span>,
-          
-              
-<span class="author-name">
-    
-        Zhang, Yi
-    
-</span>,
-          
-          
-              
-<span class="author-name">
-    
-        Gilpin, Leilani
-    
-</span>
-          
-      
-  </div>
-
-
-            </div>
-
-            <div class="pub-publication">
-                
-                    Advances in Neural Information Processing Systems
-                
-                
-                <div itemprop="datePublished">
-                    
-                        December, 2024
-                    
-                </div>
-            </div>
-
-            <div class="pub-links">
-                
-
-
-
-<a class="btn btn-primary btn-outline btn-xs" href="https://aiea-lab.github.io/publication/right-this-way-can-vlms-guide-us-to-see-more-to-answer-questions-2024/">Details</a>
-
-
-<a class="btn btn-primary btn-outline btn-xs" href="https://proceedings.neurips.cc/paper_files/paper/2024/file/efe4e50d492fedc0dfd2959f3320a974-Paper-Conference.pdf">PDF</a>
 
 
 
@@ -1401,23 +1352,6 @@
                 
                     <div class="col-xs-12 col-md-3">
     <div id="profile">
-        <a href="https://aiea-lab.github.io/member/jonathan_m/">
-            <div class="portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/jonathan_m.jpg');"></div>
-        </a>
-        <div class="portrait-title">
-            <h2 itemprop="name"><a href="https://aiea-lab.github.io/member/jonathan_m/">Jonathan Morris</a></h2>
-            
-                <h4>Undergrad Student, UC Santa Cruz</h4>
-            
-        </div>
-    </div>
-</div>
-
-                
-            
-                
-                    <div class="col-xs-12 col-md-3">
-    <div id="profile">
         <a href="https://aiea-lab.github.io/member/vishrut_s/">
             <div class="portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/vishrut_s.jpg');"></div>
         </a>
@@ -1578,6 +1512,23 @@
             <h2 itemprop="name"><a href="https://aiea-lab.github.io/member/yilun_z/">Yilun Zhou</a></h2>
             
                 <h4>Collaborator, UC Santa Cruz</h4>
+            
+        </div>
+    </div>
+</div>
+
+                
+            
+                
+                    <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <a href="https://aiea-lab.github.io/member/jonathan_m/">
+            <div class="portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/jonathan_m.jpg');"></div>
+        </a>
+        <div class="portrait-title">
+            <h2 itemprop="name"><a href="https://aiea-lab.github.io/member/jonathan_m/">Jonathan Morris</a></h2>
+            
+                <h4>Masters Student, UC Santa Cruz</h4>
             
         </div>
     </div>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -1,2673 +1,2917 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>AIEA Lab</title>
-    <link>https://aiea-lab.github.io/</link>
-    <description>Recent content on AIEA Lab</description>
-    <generator>Hugo</generator>
-    <language>en</language>
-    <copyright>&amp;copy; AIEA Lab, 2023 </copyright>
-    <lastBuildDate>Tue, 31 Mar 2026 00:00:00 +0000</lastBuildDate>
-    <atom:link href="https://aiea-lab.github.io/index.xml" rel="self" type="application/rss+xml" />
-    <item>
-      <title>Undergraduate Student</title>
-      <link>https://aiea-lab.github.io/auditor/ran_chen/</link>
-      <pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ran_chen/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/adithi/</link>
-      <pubDate>Fri, 23 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/adithi/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/haardhik_ma/</link>
-      <pubDate>Sun, 18 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/haardhik_ma/</guid>
-      <description>&lt;p&gt;authors = []&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/gaurijain/</link>
-      <pubDate>Tue, 13 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/gaurijain/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/anishbansal/</link>
-      <pubDate>Tue, 13 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/anishbansal/</guid>
-      <description>&lt;p&gt;.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/raunak_anwar/</link>
-      <pubDate>Tue, 13 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/raunak_anwar/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/sashreek/</link>
-      <pubDate>Mon, 12 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sashreek/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/chanchal/</link>
-      <pubDate>Sat, 10 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/chanchal/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Auditor</title>
-      <link>https://aiea-lab.github.io/auditor/haatim_ali/</link>
-      <pubDate>Fri, 09 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/haatim_ali/</guid>
-      <description>&lt;p&gt;I am a first year proposed Computer Science major interested in Artificial Ingelligence and Maching Learning. I love playing soccer, going on hikes, and hanging out with friends.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/ron/</link>
-      <pubDate>Thu, 08 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ron/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/aneshkondor/</link>
-      <pubDate>Thu, 08 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/aneshkondor/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/jacob_wei/</link>
-      <pubDate>Thu, 08 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/jacob_wei/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/omer_boztepe/</link>
-      <pubDate>Wed, 07 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/omer_boztepe/</guid>
-      <description>&lt;p&gt;Put your bio here.&#xA;My name is Omer Boztepe. I am a 4th year CS major at UCSC.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergradute</title>
-      <link>https://aiea-lab.github.io/auditor/marco/</link>
-      <pubDate>Wed, 07 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/marco/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Student</title>
-      <link>https://aiea-lab.github.io/auditor/riddhi/</link>
-      <pubDate>Tue, 06 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/riddhi/</guid>
-      <description>&lt;p&gt;Hi, my name is Riddhi Mundhra. I am a third-year UCSC Computer Science (Game Design) and Computer Engineering student. I am interested in AI/ML, autonomous vehicles, game development, and full-stack software projects.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/ashwin_vinod/</link>
-      <pubDate>Tue, 06 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ashwin_vinod/</guid>
-      <description>&lt;p&gt;Hey, my name is Ashwin! I&amp;rsquo;m a 2nd year computer science major at UCSC. I&amp;rsquo;m interested in procedural content generation, and neural networks.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/sree_gudapati/</link>
-      <pubDate>Tue, 06 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sree_gudapati/</guid>
-      <description>&lt;p&gt;I am a Computer Science Student at UC Santa Cruz with a passion for computer vision, machine learning, and full-stack development. Currently, I am participating in a project with Slugbotics , where I am working on integrating neural networks into autonomous systems for road hazard detection . As an aspiring Software Engineer, I am dedicated to applying these technical skills to solve complex, real-world problems&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Auditor</title>
-      <link>https://aiea-lab.github.io/auditor/vseslav/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/vseslav/</guid>
-      <description>&lt;p&gt;Vseslav Kazakov (Vee for short) is a Computer Science Game Design Student at UC Santa Cruz interested in low level programming and AI research. Vee joined the AIEA lab Winter 2026 to work on Autonomous vehicles research.&lt;/p&gt;&#xA;&lt;!-- You can write $\LaTeX$ and *Markdown* here.&#xA;&#xA;# Minyae adgnoscitque fugiebat parentis ausum superos huius&#xA;&#xA;## Ait erili meruisse iactatis omnibus erat&#xA;&#xA;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse **mira mortisque leones**! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert *magno*, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&#xA;&#xA;&gt; Ultusque saltem crimine palluit virgineos deum nec pectusque oculis [que quos&#xA;&gt; lactea](http://habenas.com/.php) quae? Animus feriendus ductae! *Theron* sua&#xA;&gt; amans, est nulla cadavera, aquarum servavit quoque missus, hac texit videre,&#xA;&gt; valuere est erant? --&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/anurag_n/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/anurag_n/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/ashwin_senthilvasan/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ashwin_senthilvasan/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/collin/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/collin/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/crystal/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/crystal/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/idohaiby/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/idohaiby/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/justin_r/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/justin_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/nathan_yee/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/nathan_yee/</guid>
-      <description>&lt;p&gt;Computer Engineering student passionate about building intelligent systems at the intersection of software and hardware. I bring strong skills in machine learning, systems programming, algorithms, and autonomous systems development, with hands-on experience across the full technology stack. From low-level FPGA design to high-level AI applications. I thrive on solving complex technical problems and am particularly drawn to projects that combine analytical thinking with real-world impact.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/roshni_gundavelli/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/roshni_gundavelli/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/rudra_c/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/rudra_c/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/sergio_h/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sergio_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/tania/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tania/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate Student</title>
-      <link>https://aiea-lab.github.io/auditor/george/</link>
-      <pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/george/</guid>
-      <description>&lt;p&gt;Hello.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>member</title>
-      <link>https://aiea-lab.github.io/member/nazanin/</link>
-      <pubDate>Sun, 09 Nov 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/nazanin/</guid>
-      <description>&lt;p&gt;Nazanin is an independent researcher and a collaborator.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate Student</title>
-      <link>https://aiea-lab.github.io/auditor/victor/</link>
-      <pubDate>Sun, 19 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/victor/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/bardia/</link>
-      <pubDate>Sat, 18 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/bardia/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/naomi/</link>
-      <pubDate>Tue, 14 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/naomi/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/zaki/</link>
-      <pubDate>Tue, 14 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/zaki/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/ajmcdaniel/</link>
-      <pubDate>Sun, 12 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ajmcdaniel/</guid>
-      <description>&lt;p&gt;AJ McDaniel is an undergraduate Computer Science student at UC Santa Cruz and a member of the AIEA Lab, where he explores the intersection of artificial intelligence, software engineering, and human-centered design. His interests include explainable AI, responsible system design, and applications of machine learning in education and healthcare. AJ has experience as a Data &amp;amp; AI/ML Engineering Intern at ResMed and conducts research in runtime verification and trustworthy AI at the University of Illinois Urbana-Champaign. Outside of research, he leads student tech initiatives, mentors peers in programming and circuit design, and actively participates in hackathons and engineering outreach.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Follow My Lead: Logical Fallacy Classification with Knowledge-Augmented LLMs</title>
-      <link>https://aiea-lab.github.io/publication/follow-my-lead-logical-fallacy-classification-with-knowledge-augmented-llms-2025/</link>
-      <pubDate>Sat, 11 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/follow-my-lead-logical-fallacy-classification-with-knowledge-augmented-llms-2025/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/tora_m/</link>
-      <pubDate>Fri, 10 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tora_m/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/member/caleb/</link>
-      <pubDate>Fri, 10 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/caleb/</guid>
-      <description>&lt;p&gt;Caleb Bergen is an undergraduate student at UC Santa Cruz majoring in Computer Science. His current work examines the effectiveness and ethics of using large language models (LLMs) as driving assistants for autonomous vehicles in simulations.&lt;/p&gt;&#xA;&lt;p&gt;Caleb holds an A.S. in Mathematics and an A.S. in Computer Science (both with highest honors) from Fresno City College. He transferred to UC Santa Cruz in the fall of 2024 and will be graduating in the spring 2026 quarter. His other hobbies including watching sports, playing board games, and walking around UC Santa Cruz&amp;rsquo;s beautiful campus.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>BS</title>
-      <link>https://aiea-lab.github.io/auditor/inikabhargava/</link>
-      <pubDate>Wed, 08 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/inikabhargava/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/jatikilt/</link>
-      <pubDate>Mon, 06 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/jatikilt/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate Researcher</title>
-      <link>https://aiea-lab.github.io/auditor/surya_jagarlamudi/</link>
-      <pubDate>Mon, 06 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/surya_jagarlamudi/</guid>
-      <description>&lt;p&gt;Surya Jagarlamudi is a Computer Engineering undergraduate at UC Santa Cruz focusing on artificial intelligence, computational modeling, and full-stack software systems. He is passionate about using technology to create adaptive, human-centered solutions in engineering and data-driven decision making.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Explore the Loss space with Hill-ADAM</title>
-      <link>https://aiea-lab.github.io/publication/explore-the-loss-space-with-hill-adam-2025/</link>
-      <pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/explore-the-loss-space-with-hill-adam-2025/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/pravin/</link>
-      <pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/pravin/</guid>
-      <description>&lt;p&gt;&amp;ldquo;3rd year Computer Engineering student at UC Santa Cruz excited to explore the edges of AI and expand the frontier&amp;rdquo;&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergradute</title>
-      <link>https://aiea-lab.github.io/auditor/dheshnaa_madasamy/</link>
-      <pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/dheshnaa_madasamy/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergradute</title>
-      <link>https://aiea-lab.github.io/auditor/farhan_ali/</link>
-      <pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/farhan_ali/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/arnav_d/</link>
-      <pubDate>Thu, 02 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/arnav_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/jesus_cuevas/</link>
-      <pubDate>Thu, 02 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/jesus_cuevas/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/siddharth_m/</link>
-      <pubDate>Wed, 01 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/siddharth_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/parsh_gandhi/</link>
-      <pubDate>Wed, 01 Oct 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/parsh_gandhi/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/anurag_c/</link>
-      <pubDate>Tue, 30 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/anurag_c/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/jaisree/</link>
-      <pubDate>Tue, 30 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/jaisree/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/trisha_moorkoth/</link>
-      <pubDate>Tue, 30 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/trisha_moorkoth/</guid>
-      <description>&lt;p&gt;Hi I&amp;rsquo;m Trisha! I&amp;rsquo;m a 4th year CS major interested in explainable AI and building educational tools!&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/amanvars/</link>
-      <pubDate>Mon, 29 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/amanvars/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/matthew_k/</link>
-      <pubDate>Mon, 29 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/matthew_k/</guid>
-      <description>&lt;p&gt;Matthew Kimotsuki is a 4th year computer science student at UCSC with an interest in AI safety and ethics.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate student</title>
-      <link>https://aiea-lab.github.io/auditor/dongjun_h/</link>
-      <pubDate>Mon, 29 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/dongjun_h/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>VFSI: Validity First Spatial Intelligence for Constraint-Guided Traffic Diffusion</title>
-      <link>https://aiea-lab.github.io/publication/vfsi-validity-first-spatial-intelligence-for-constraint-guided-traffic-diffusion-2025/</link>
-      <pubDate>Sun, 28 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/vfsi-validity-first-spatial-intelligence-for-constraint-guided-traffic-diffusion-2025/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>NeSy Law</title>
-      <link>https://aiea-lab.github.io/project/nesylaw/</link>
-      <pubDate>Sat, 27 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/project/nesylaw/</guid>
-      <description>&lt;p&gt;The NeSy (previously known as LLM + Law) project focuses on harvesting the power of symbolic language and Neuro-symbolic AI for legal use cases.&#xA;Neuro-symbolic AI (also known as NeSy) is a field that combines the generalizability of Neural Networks and interpretability and control of Symbolic AI. The highly structured setup with potential capability for formal verification is a great fit for the legal field. Its generalizability is promising to lift up the burden of heavy legal document review and drafting&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Neuron Explanations</title>
-      <link>https://aiea-lab.github.io/project/neuron_expl/</link>
-      <pubDate>Sat, 27 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/project/neuron_expl/</guid>
-      <description>&lt;p&gt;The Neuron Explanation project aims to understand what deep neural networks (CNN, LLMs) learn during the training process by analyzing what individual neurons are able to recognize in terms of concepts (e.g., cat, building, etc). Specifically, we aim to achieve this goal by associating logical rules (e.g., (Cat OR Dog) AND NOT person)) to each neuron that express the (spatial) alignment between neurons activations and concept locations. These rules are usually extracted by combining search algorithms, clustering algorithms and statistical analysis of neurons activation.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/andre_chen/</link>
-      <pubDate>Sat, 27 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/andre_chen/</guid>
-      <description>&lt;p&gt;Putting bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/aman_avinash/</link>
-      <pubDate>Fri, 26 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/aman_avinash/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergrad Auditor</title>
-      <link>https://aiea-lab.github.io/auditor/kkasturi/</link>
-      <pubDate>Tue, 23 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/kkasturi/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/evan_kaiden/</link>
-      <pubDate>Mon, 01 Sep 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/evan_kaiden/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Auditor</title>
-      <link>https://aiea-lab.github.io/auditor/bhavyashanmugam/</link>
-      <pubDate>Thu, 07 Aug 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/bhavyashanmugam/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/bolor_b/</link>
-      <pubDate>Thu, 10 Jul 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/bolor_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/stanley/</link>
-      <pubDate>Thu, 10 Jul 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/stanley/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/divya_j/</link>
-      <pubDate>Thu, 03 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/divya_j/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/adam_m/</link>
-      <pubDate>Wed, 02 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/adam_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/michael_zhou/</link>
-      <pubDate>Wed, 02 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/michael_zhou/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/koushik/</link>
-      <pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/koushik/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Masters</title>
-      <link>https://aiea-lab.github.io/member/charlie_a/</link>
-      <pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/charlie_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergrad Student</title>
-      <link>https://aiea-lab.github.io/auditor/shripad_m/</link>
-      <pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/shripad_m/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergrad Student, UCSC</title>
-      <link>https://aiea-lab.github.io/auditor/ash/</link>
-      <pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ash/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/tisha/</link>
-      <pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tisha/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Lab Auditor</title>
-      <link>https://aiea-lab.github.io/auditor/william_ho/</link>
-      <pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/william_ho/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergrad</title>
-      <link>https://aiea-lab.github.io/auditor/chris_camberos/</link>
-      <pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/chris_camberos/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/neha_h/</link>
-      <pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/neha_h/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/member/jetha/</link>
-      <pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/jetha/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate Student</title>
-      <link>https://aiea-lab.github.io/auditor/harini/</link>
-      <pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/harini/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate Student</title>
-      <link>https://aiea-lab.github.io/auditor/nickolas_t/</link>
-      <pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/nickolas_t/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate Student</title>
-      <link>https://aiea-lab.github.io/auditor/yashas/</link>
-      <pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/yashas/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Auditor</title>
-      <link>https://aiea-lab.github.io/auditor/satvik_k/</link>
-      <pubDate>Sat, 01 Mar 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/satvik_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/rami_al_habash/</link>
-      <pubDate>Sat, 11 Jan 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/rami_al_habash/</guid>
-      <description>&lt;p&gt;I am an undergraduate student at UCSC researching AI Explainability and Accountability. I am also a part-time Code Coach. I&amp;rsquo;m also a big soccer fan! For any inquiries, feel free to reach me at the email above.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Auditor</title>
-      <link>https://aiea-lab.github.io/auditor/kunwarpalsingh/</link>
-      <pubDate>Sun, 05 Jan 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/kunwarpalsingh/</guid>
-      <description>&lt;p&gt;Hi, my name is Kunwarpal Singh and I am currently a 2nd year Computer Science Student. One of the reasons that I am joining AIEA lab is because I want to pursue research in AI.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/mahir_camci/</link>
-      <pubDate>Sun, 05 Jan 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/mahir_camci/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/nithin/</link>
-      <pubDate>Sun, 05 Jan 2025 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/nithin/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Autonomous driving with spiking neural networks</title>
-      <link>https://aiea-lab.github.io/publication/autonomous-driving-with-spiking-neural-networks-2024/</link>
-      <pubDate>Mon, 16 Dec 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/autonomous-driving-with-spiking-neural-networks-2024/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Right this way: Can VLMs Guide Us to See More to Answer Questions?</title>
-      <link>https://aiea-lab.github.io/publication/right-this-way-can-vlms-guide-us-to-see-more-to-answer-questions-2024/</link>
-      <pubDate>Mon, 16 Dec 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/right-this-way-can-vlms-guide-us-to-see-more-to-answer-questions-2024/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/clayton/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/clayton/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/sean_s/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/sean_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/johnathan_h/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/johnathan_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/joshua_s/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/joshua_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/nihal_e/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/nihal_e/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/pragya_m/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/pragya_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sahil_k/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sahil_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/varsana_i/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/varsana_i/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/vihan_p/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/vihan_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/mahika_g/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/mahika_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/sahiel_b/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/sahiel_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/shanay_g/</link>
-      <pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/shanay_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/aaja_o/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/aaja_o/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/aishwarya_r/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/aishwarya_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/alex_s/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/alex_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/anirudh_s/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/anirudh_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/njeri_g/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/njeri_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/advait_s/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/advait_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/ethan_h/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/ethan_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/rohith_k/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/rohith_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/swara_m/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/swara_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/daksh_s/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/daksh_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/rushil_n/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/rushil_n/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/shiyuan_h/</link>
-      <pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/shiyuan_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/janvi_r/</link>
-      <pubDate>Tue, 15 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/janvi_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/mahika_p/</link>
-      <pubDate>Tue, 15 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/mahika_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ananya_d/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ananya_d/</guid>
-      <description>&lt;p&gt;Here for the vibes&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/dhanishtha_p/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/dhanishtha_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/kendrick_n/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/kendrick_n/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/michael_s/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/michael_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/nistha/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/nistha/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/prathik_k/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/prathik_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/rami_w/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/rami_w/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/richard_d/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/richard_d/</guid>
-      <description>&lt;p&gt;Richard Dao has a Bachelor’s in Computer Science from UC Santa Cruz. His research interests include autonomous vehicle path planning and spiking neural networks. He currently participates in two labs with Dr. Leilani H. Gilpin and Dr. Jason Eshraghian respectively. While being active in research, Richard also works fulltime as a Software Engineer at Covenant Services Worldwide. He looks to pursue a Masters degree in Computer Science with a focus on Artificial Intelligence and Machine Learning.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/srinidhi_s/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/srinidhi_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/vinh/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/vinh/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/yuan_j/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/yuan_j/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/yuhaendan_b/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/yuhaendan_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/abhita/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/abhita/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/annika/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/annika/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/arnav/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/arnav/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/ashton_l/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ashton_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/ayush_r/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ayush_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/dan_p/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/dan_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/denise_a/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/denise_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/jaskaran_s/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/jaskaran_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/kevin_k/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/kevin_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/laurena_c/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/laurena_c/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/levi_l/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/levi_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/maharshi_m/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/maharshi_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/nathan_n/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/nathan_n/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/raghav_s/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/raghav_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/rahul_p/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/rahul_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/raviteja_p/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/raviteja_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/reva_a/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/reva_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/saachi_b/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/saachi_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sai_p/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sai_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/surabhi_k/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/surabhi_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/tanvi_j/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tanvi_j/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/tejas/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tejas/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/varnit_b/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/varnit_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/vijay_a/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/vijay_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/xuan_j/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/xuan_j/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/arush_g/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/arush_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/ayush_r/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/ayush_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/creighton_g/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/creighton_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/dominick_r/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/dominick_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/hugo_l/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/hugo_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/karman_s/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/karman_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/krishna_d/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/krishna_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/mahyar_v/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/mahyar_v/</guid>
-      <description>&lt;p&gt;I am an Iranian-born student who moved to the USA at the age of 12. I have lived in Santa Cruz since I migrated, eventually got to persue my higher degree in Computer Sicence @ UCSC. I am working to learn more about LLM and chatbots, as they are one of the many fields that I’ve shown a keen interest in. I am also a Teaching Assistant under Professor Tantalo’s guidance in Data Structures and Algorithms. I hope to keep this job until I graduate and have some Software related job to look forward to post grad.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/nataniel_j/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/nataniel_j/</guid>
-      <description>&lt;p&gt;Hello, I’m Nataniel, a second-year undergrad student pursing computer engineering in UCSC.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/rishika_s/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/rishika_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/suhas_o/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/suhas_o/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/surabhi_k/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/surabhi_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/vihan_p/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/vihan_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/vik_d/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/vik_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/zhonghui_l/</link>
-      <pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/zhonghui_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/akash_malampati/</link>
-      <pubDate>Sun, 06 Oct 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/akash_malampati/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ziyuan/</link>
-      <pubDate>Sun, 15 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ziyuan/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/abby/</link>
-      <pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/abby/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/karthik/</link>
-      <pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/karthik/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/meenal/</link>
-      <pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/meenal/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/rohan_g/</link>
-      <pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/rohan_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/ashwin_n/</link>
-      <pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/ashwin_n/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/jonathan_m/</link>
-      <pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/jonathan_m/</guid>
-      <description>&lt;p&gt;I love to do cool things! 😎&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ameyaa_b/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ameyaa_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/andrew_s/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/andrew_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/brendon_c/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/brendon_c/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/jaivin_p/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/jaivin_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/max_m/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/max_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/olivia_a/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/olivia_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/poonam_d/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/poonam_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/sidharth_b/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/sidharth_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/anish/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/anish/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/kendrick_n/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/kendrick_n/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/justin_s/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/justin_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/shlok_m/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/shlok_m/</guid>
-      <description>&lt;p&gt;Hi! I’m Shlok, a freshmen at Dougherty Valley High.  I like CS, and I’m passionate about how computer systems work with each other. If you want to contact me, visit my website :)&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/tanisha_p/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/tanisha_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/vishrut_s/</link>
-      <pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/vishrut_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/akashleena/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/akashleena/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/alex_f/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/alex_f/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/amos_l/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/amos_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/anish/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/anish/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/anthony/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/anthony/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/anuj_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/anuj_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/arka_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/arka_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/betsy/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/betsy/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/bo_y/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/bo_y/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/brandon_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/brandon_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/calvin_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/calvin_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/camden_b/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/camden_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/coen_a/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/coen_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/daniel_h/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/daniel_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/daniel_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/daniel_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/dennis/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/dennis/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/erick_h/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/erick_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/evan_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/evan_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/fariha_l/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/fariha_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/gene_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/gene_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/harshini_v/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/harshini_v/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ish_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ish_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/jacob_l/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/jacob_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/janvi/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/janvi/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/jason_w/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/jason_w/</guid>
-      <description>&lt;p&gt;Jason Wu is an undergraduate student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His research focuses on developing full stack web applications and exploring the utility of large language models (LLMs).&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/jihang_l/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/jihang_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/jimmy_f/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/jimmy_f/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/john_y/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/john_y/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/kajal_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/kajal_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/keely_w/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/keely_w/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/krithik_d/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/krithik_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/macklin/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/macklin/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/maithili/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/maithili/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/michael_m/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/michael_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/oliver_l/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/oliver_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/owen_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/owen_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/pratik_d/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/pratik_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/raj_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/raj_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/rangasri_c/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/rangasri_c/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/rithesh/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/rithesh/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ritvik_r/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ritvik_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/roger_l/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/roger_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/rohit_d/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/rohit_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ryan_a/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ryan_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ryan_l/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ryan_l/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/ryan_w/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/ryan_w/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/sahil_g/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/sahil_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/samuel_c/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/samuel_c/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/samuel_t/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/samuel_t/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/sebastian/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/sebastian/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/sela/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/sela/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/shashwat/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/shashwat/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/shayan_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/shayan_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/shiva_g/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/shiva_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/shoto/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/shoto/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/smruthi_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/smruthi_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/sukhveer_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/sukhveer_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/suneet_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/suneet_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/supriya_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/supriya_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/tommy_c/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/tommy_c/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/vaibhav/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/vaibhav/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/vid/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/vid/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/vidya/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/vidya/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/william_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/william_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/alumni/yanwen/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/yanwen/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/aidan_a/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/aidan_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/aiven_j/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/aiven_j/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/ameek_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ameek_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/anshika/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/anshika/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/daniel/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/daniel/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/harsh/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/harsh/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/ian/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/ian/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/krishna_d/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/krishna_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/lily_f/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/lily_f/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/nathan/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/nathan/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/neha_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/neha_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/prathik_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/prathik_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/rajat/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/rajat/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sahib_a/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sahib_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sahil_n/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sahil_n/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/samiyah/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/samiyah/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sanya_m/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sanya_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/satwik_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/satwik_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/saumit_v/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/saumit_v/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sean_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sean_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sebastian/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sebastian/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/selam/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/selam/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sidharth_b/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sidharth_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sophie_h/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sophie_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/sri/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/sri/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/srinidhi/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/srinidhi/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/suhas/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/suhas/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/tanishq_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tanishq_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/tanvi/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tanvi/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/tavleen/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tavleen/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/tavleen_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/tavleen_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/thomas/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/thomas/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/umair/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/umair/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/vik_d/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/vik_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/abhay_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/abhay_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/adarsh_m/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/adarsh_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/adithya_g/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/adithya_g/</guid>
-      <description>&lt;p&gt;I am a high school student from the Bay Area. My current research lies in the intersections of eXplainable AI and GenerativeAI, and the application of eXplainabile systems.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/aditi_c/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/aditi_c/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/aiden_h/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/aiden_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/akshat_b/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/akshat_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/ashmit_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/ashmit_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/ava_t/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/ava_t/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/ayush_b/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/ayush_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/bhargav_e/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/bhargav_e/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/devansh_g/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/devansh_g/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/diyan_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/diyan_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/jaivin_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/jaivin_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/justin_h/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/justin_h/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/jyotiraditya_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/jyotiraditya_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/krish_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/krish_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/lucas_c/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/lucas_c/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/mahika_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/mahika_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/nitin_j/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/nitin_j/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/prisha_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/prisha_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/ritvik_r/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/ritvik_r/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/shiven_e/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/shiven_e/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/shlok_a/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/shlok_a/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/shri_c/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/shri_c/</guid>
-      <description>&lt;p&gt;I’m a junior in California High School, San Ramon. Outside of coding, I really like playing soccer and producing music.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/sumedha_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/sumedha_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/tanvi_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/tanvi_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/tito_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/tito_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/vera_f/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/vera_f/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/yannis_s/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/yannis_s/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/intern/yuhaendan_b/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/yuhaendan_b/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/arnav_k/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/arnav_k/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/ashwin_p/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/ashwin_p/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/bill_z/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/bill_z/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/ivan_d/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/ivan_d/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/priyesh_v/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/priyesh_v/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/sabrina/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/sabrina/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/siddarth_m/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/siddarth_m/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/ujwala/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/ujwala/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/vaishnavi_j/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/vaishnavi_j/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/member/yilun_z/</link>
-      <pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/yilun_z/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Proslm: A prolog synergized language model for explainable domain specific knowledge based question answering</title>
-      <link>https://aiea-lab.github.io/publication/proslm-a-prolog-synergized-language-model-for-explainable-domain-specific-knowledge-based-question-answering-2024/</link>
-      <pubDate>Mon, 09 Sep 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/proslm-a-prolog-synergized-language-model-for-explainable-domain-specific-knowledge-based-question-answering-2024/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Slug Mobile: Test-Bench for RL Testing</title>
-      <link>https://aiea-lab.github.io/publication/slug-mobile-test-bench-for-rl-testing-2024/</link>
-      <pubDate>Sat, 31 Aug 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/slug-mobile-test-bench-for-rl-testing-2024/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Project Lead</title>
-      <link>https://aiea-lab.github.io/member/shreyan/</link>
-      <pubDate>Tue, 13 Aug 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/shreyan/</guid>
-      <description>&lt;p&gt;I am a student researcher and software developer focused on making machine learning more robust, accessible, and sustainable.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Lab Intern</title>
-      <link>https://aiea-lab.github.io/intern/tanishapatil/</link>
-      <pubDate>Mon, 22 Jul 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/intern/tanishapatil/</guid>
-      <description>&lt;p&gt;Tanisha Patil is a collaborative high school student pursuing a position in data science and machine learning. She seeks to use data analysis, modeling, and programming to support data-driven decision making and yield positive social impact.&lt;/p&gt;&#xA;&lt;p&gt;Outside of research, Tanisha enjoys playing field hockey and solving the daily NYT puzzles.&lt;/p&gt;&#xA;&lt;!-- You can write $\LaTeX$ and *Markdown* here.&#xA;&#xA;# Minyae adgnoscitque fugiebat parentis ausum superos huius&#xA;&#xA;## Ait erili meruisse iactatis omnibus erat&#xA;&#xA;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse **mira mortisque leones**! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert *magno*, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&#xA;&#xA;&gt; Ultusque saltem crimine palluit virgineos deum nec pectusque oculis [que quos&#xA;&gt; lactea](http://habenas.com/.php) quae? Animus feriendus ductae! *Theron* sua&#xA;&gt; amans, est nulla cadavera, aquarum servavit quoque missus, hac texit videre,&#xA;&gt; valuere est erant? --&gt;</description>
-    </item>
-    <item>
-      <title>PhD Student, Activist, Strange Loop</title>
-      <link>https://aiea-lab.github.io/member/jackfoxkeen/</link>
-      <pubDate>Mon, 22 Jul 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/jackfoxkeen/</guid>
-      <description>&lt;p&gt;Jack Fox Keen is a second year PhD student in the Department of Computer Science and Engineering at UC Santa Cruz, under the tutelage of Dr. Leilani H. Gilpin. Jack&amp;rsquo;s research focuses on explainable artificial intelligence for psychological and sociological applications. Jack holds a bachelors of science from Florida Student University for both Scientific Computing and Biomathematics. Jack was the lead data scientist at the Guardian Project for ProofMode, working with the Content Authenticity Initiative (CAI) and other organizations, such as Adobe, on verifiable photo provenance. Some of Jack&amp;rsquo;s favorite hobbies include writing, painting, and hiking.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>PostDoc</title>
-      <link>https://aiea-lab.github.io/member/biagio/</link>
-      <pubDate>Mon, 22 Jul 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/biagio/</guid>
-      <description>&lt;p&gt;Mattia is a PostDoc in the Department of Computer Science and Engineering at UC Santa Cruz, under the supervision of Dr. Leilani H. Gilpin. Mattia&amp;rsquo;s research focuses on explainable artificial intelligence for  deep neural networks. He is interested in Neuron Explanations (understand what knowledge AI learns) and Self-Explainable Deep Neural Networks (AI that can explain itself). Mattia holds a PhD in Computer Engineering, a M.S. in Artificial Intelligence and Robotics, and a B.S. in Computer science, all from Sapienza University of Rome.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Accountability layers: explaining complex system failures by parts</title>
-      <link>https://aiea-lab.github.io/publication/accountability-layers-explaining-complex-system-failures-by-parts-2023/</link>
-      <pubDate>Mon, 15 Jul 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/accountability-layers-explaining-complex-system-failures-by-parts-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>A novel post-hoc explanation comparison metric and applications</title>
-      <link>https://aiea-lab.github.io/publication/a-novel-post-hoc-explanation-comparison-metric-and-applications-2024/</link>
-      <pubDate>Tue, 18 Jun 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/a-novel-post-hoc-explanation-comparison-metric-and-applications-2024/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>BS at UCSC</title>
-      <link>https://aiea-lab.github.io/alumni/raj/</link>
-      <pubDate>Mon, 17 Jun 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/raj/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Research Scientist</title>
-      <link>https://aiea-lab.github.io/alumni/nikhil/</link>
-      <pubDate>Mon, 13 May 2024 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/nikhil/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Towards a fuller understanding of neurons with clustered compositional explanations</title>
-      <link>https://aiea-lab.github.io/publication/towards-a-fuller-understanding-of-neurons-with-clustered-compositional-explanations-2023/</link>
-      <pubDate>Fri, 15 Dec 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/towards-a-fuller-understanding-of-neurons-with-clustered-compositional-explanations-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>MS at UCSC</title>
-      <link>https://aiea-lab.github.io/alumni/rangasri/</link>
-      <pubDate>Fri, 01 Dec 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/rangasri/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>PhD Student</title>
-      <link>https://aiea-lab.github.io/member/oliverchang/</link>
-      <pubDate>Fri, 27 Oct 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/oliverchang/</guid>
-      <description>&lt;p&gt;Oliver Chang is a computer science and engineering PhD student at UC Santa Cruz.  His research&#xA;focuses on robust and efficient deep reinforcement learning. His work has applications to autonomous vehicles, efficient data sampling, and out of distribution learning. His current&#xA;work examines how salient maps could be a memory efficient medium to store in a replay buffer.&lt;/p&gt;&#xA;&lt;p&gt;He holds a B.A. in Computer Science and Mathematics from Pomona College.  Outside of research,&#xA;Oliver enjoys running, watching baseball, and solving math puzzles - but not necessarily in that order.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Can large language models explain themselves? a study of llm-generated self-explanations</title>
-      <link>https://aiea-lab.github.io/publication/can-large-language-models-explain-themselves-a-study-of-llm-generated-self-explanations-2023/</link>
-      <pubDate>Tue, 17 Oct 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/can-large-language-models-explain-themselves-a-study-of-llm-generated-self-explanations-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Convolutional neural network model for diabetic retinopathy feature extraction and classification</title>
-      <link>https://aiea-lab.github.io/publication/convolutional-neural-network-model-for-diabetic-retinopathy-feature-extraction-and-classification-2023/</link>
-      <pubDate>Mon, 16 Oct 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/convolutional-neural-network-model-for-diabetic-retinopathy-feature-extraction-and-classification-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/alumni/nick_w/</link>
-      <pubDate>Mon, 09 Oct 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/nick_w/</guid>
-      <description>&lt;p&gt;Nick Wang is a 3rd year undergraduate student studying Computer Science at UC Santa Cruz. He is deeply curious about how machine learning works (hence XAI) and has recently become motivated to improve his understanding of AVs which he will be able to do while working on the driving rules project and the drive sim project.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Ph.D. student</title>
-      <link>https://aiea-lab.github.io/member/peiyu/</link>
-      <pubDate>Sat, 07 Oct 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/peiyu/</guid>
-      <description>&lt;p&gt;Olivia is a first-year Ph.D. student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. Her research interests include but are not limited to XAI, HCAI, and NLP.&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;https://olivianxai.github.io/&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Ph.D. student</title>
-      <link>https://aiea-lab.github.io/member/sijia/</link>
-      <pubDate>Sat, 07 Oct 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/sijia/</guid>
-      <description>&lt;p&gt;Sijia is a first-year Ph.D. student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. She has an interest in the explainability of model intelligence (XAI).&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;https://szhong16.github.io/&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/shaan/</link>
-      <pubDate>Sat, 30 Sep 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/shaan/</guid>
-      <description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate</title>
-      <link>https://aiea-lab.github.io/auditor/alexanderleung/</link>
-      <pubDate>Fri, 01 Sep 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/alexanderleung/</guid>
-      <description>&lt;p&gt;Hello! My name is Alexander Leung. I’m an undergraduate auditor with interests in AI, LLM and Software Engineering&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>XAI for Mental Health</title>
-      <link>https://aiea-lab.github.io/project/xai_mental_health/</link>
-      <pubDate>Fri, 01 Sep 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/project/xai_mental_health/</guid>
-      <description>&lt;h2 id=&#34;papers&#34;&gt;Papers&lt;/h2&gt;</description>
-    </item>
-    <item>
-      <title>Aloha!</title>
-      <link>https://aiea-lab.github.io/post/aloha/</link>
-      <pubDate>Sat, 19 Aug 2023 15:50:58 +0200</pubDate>
-      <guid>https://aiea-lab.github.io/post/aloha/</guid>
-      <description>&lt;p&gt;Aloha to friends and collaborators of the lab!  We&amp;rsquo;ve just started setting up this website and we appreciate your patience as we make changes.&lt;/p&gt;&#xA;&lt;p&gt;Mahalo!&lt;/p&gt;&#xA;&lt;!--&#xA;# Magorum notissima limite sua pars simus sumptis&#xA;&#xA;## Incessit ignota coniunx serpunt&#xA;&#xA;Lorem markdownum ab cunas, semine commissus matrona manibusque plumis, nova sub&#xA;Spartana *loca ignibus*. In partibus muneris, paludes rara, plectrumque, fontis,&#xA;concubitus a locoque demptos exclamat conde ab aethera **nihil**.&#xA;&#xA;- Quamquam abit vulnere nec intus decidit clamor&#xA;- Nocuit quae tamen timent aperta&#xA;- Cervice preces totumque postquam nunc iacit sive&#xA;- Potestas te sis putaret sceleri totiens&#xA;- Retro profundo ad sede Iovem in este&#xA;- In ait flumina intrare Troiae&#xA;&#xA;Ut fatis *praecordia alvum iamque*, adeo tympana **male** silvas. Dammis adit&#xA;sanguine tamen lacrimis tu venias ut si gratum! [Nigrior&#xA;et](http://www.traxere-veniat.org/) saepe cum iterum cura it generosque animam&#xA;raptusque in possunt ut portat, Latreus Iason tenuit macies in. Mox cista&#xA;similis acerque celeberrima ignibus capillos et in mota conde ducta domus&#xA;capellae Minervam rapido quoque.&#xA;&#xA;## Eadem nitido in motus fretum quae gesserat&#xA;&#xA;Iacerent repellit est rivus habuit, iamque, coma nomine moenia merguntque quid,&#xA;non est cum remigis quam error. Populus **sit** et ipsaque ore non, est voce,&#xA;nec domumque habeo Palati formatur properabat. Depressitque sumit: cedite simul&#xA;pontus o **gramine** opus dum: easdem debueram ad edita!&#xA;&#xA;    if (dma &gt;= tooltip_device_joystick(62766, 15 - access)) {&#xA;        multicasting_xmp.pageWi(resources_netiquette, -5 + xhtmlCard,&#xA;                pupMountServer);&#xA;    }&#xA;    if (plug_alu_box &lt; 50 + association) {&#xA;        romDefinition.favicon += secondary * 3 * 830698;&#xA;    } else {&#xA;        dLeftVolume = -5;&#xA;        data.carrier = 341879 * pc_ocr + portDongleThermistor;&#xA;        dimmTunnelingPlug = name_parameter + dns + card_backup_megabyte;&#xA;    }&#xA;    constantMailRefresh = romDram;&#xA;    hostEcc += gif;&#xA;    if (bar(byteClick, hyper_switch) == mount_card / ntfsT) {&#xA;        link_goodput(printer, responsive + bare_ascii_core);&#xA;        abend_banner(adwareFlash + 5, flashScraping.output(-5,&#xA;                dot_hardening_driver, link_halftone_newsgroup), 4);&#xA;        mampWindow(program, -3 * unc_ttl);&#xA;    } else {&#xA;        url_perl(30, language_push.dacMenuFi(-3, keyboardApiComputer,&#xA;                hotSpreadsheet));&#xA;        im += guidFramework(sidebar.parallel(fsbNetworking), 4,&#xA;                intellectualYobibytePup(icqGate));&#xA;    }&#xA;&#xA;Aesoniden respicit, ad Ino negabat, Achivos atros, res cedere saevorum gaudia.&#xA;Reflectunt placuit. Sui iam nec tandem noctis, ferox hoc misit femineos nec,&#xA;licet?&#xA;&#xA;Melius aperit fronti sis est sua postque illic vos mihi cetera, et ante ibat&#xA;levata. Commenta nec parum declinet *superba*, verbis ad deceat dubito? Et&#xA;forcipe lacertis convicia et flentes rursus genus coniunx saxo quod; tota.&#xA;Advena tori mea rubens pressanda solus.&#xA;--&gt;</description>
-    </item>
-    <item>
-      <title>Explainable Autograder</title>
-      <link>https://aiea-lab.github.io/project/explaingrade/</link>
-      <pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/project/explaingrade/</guid>
-      <description>&lt;p&gt;Current software assessment tools or “autograders” automatically evaluate and score student programming assignments with output-based feedback, but they do not offer conceptual guidance to help students or instructors improve.  Students and instructors get a grade ,showing which test cases pass or fail,  but not a clear rationale for why those outcomes occurred.  There is a need to improve feedback for students to increase efficient learning [1], and for instructors to inform pedagogy and system evaluation [2]. The goal of this project is to address this gap by developing an explainable AI (XAI) autograder system that identifies the conceptual strengths and weaknesses in computer science student’s answers.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Explaining LLM Failures</title>
-      <link>https://aiea-lab.github.io/project/xaillm/</link>
-      <pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/project/xaillm/</guid>
-      <description>&lt;!--&#xA;# Et sensus uncos Troiaeque mori candidaque ostentis&#xA;&#xA;## Litusque praemia&#xA;&#xA;*Lorem markdownum* natus, regis cecidere. Sinebat pudoris terque si commune&#xA;pendebat ubi dubio cibique pontum virentem Nestora gaudia decebat [quoniam&#xA;eunt](http://inarmis.net/.html): graves.&#xA;[Teleste](http://www.autumni-remissis.io/ab) est colebat iamque ullis terra&#xA;neque limen Nabataeus viribus ait.&#xA;&#xA;    encoding_install_autoresponder = ultra.osiComputer(host.ccdColdWddm(fsb,&#xA;            compressionAlignment), 324317, adsl_application);&#xA;    if (exbibyte(remoteCopy.pplVirtualUrl(3, hardOopBoot), solid, 46)) {&#xA;        eide_podcast(trinitron.statusRawApple(class, cmyk_gigabit));&#xA;        ddrEcc(maximizeRw, appletPersonal);&#xA;        hdd_null = pretest_window_rup;&#xA;    } else {&#xA;        system += hdd + 396409 - firewallLanMedia;&#xA;    }&#xA;    var firmware_wan = api(boot_winsock_us, 1, domainNetbios) + web_veronica_sql&#xA;            + javascriptCtrPppoe.balancing(smtp, 1);&#xA;&#xA;## Reperire haec Iunone dolor talaria eque maesto&#xA;&#xA;Letalem et nomen animalia summaque. Vivit et regione bracchia cui prosiliunt&#xA;videat; sol cuius inquit siquid est labens, nomina? Alcimedon nomine spectarat.&#xA;&#xA;1. Reticere longeque te&#xA;2. Plenissima silet cui gentem eripere&#xA;3. Super agros dum clarus saepe supra&#xA;4. Scelerata ianua non nostris Nisi&#xA;5. Aperta sedes nec cingentibus pectore ullos cum&#xA;&#xA;## Quot locus errans relinquitur fuit densa tractum&#xA;&#xA;Nec meas et lecto ilia vulnera, haec Acmon conprecor venam Mopsopium lacrimis&#xA;novi intempestiva cognoscere concordia promittit cui. Tabo torpet in cavas tot&#xA;Stygios ego potest indicat, pinguis quaeque confertur? Mihi *vultumque vulgusque&#xA;quem* Narve, illa est *vestigia* flammas, cum visus semper abesse, tollens inde&#xA;dereptis, ut! Verbere honorum: idem hic facit inmitibus, hostilia quoque quem?&#xA;&#xA;1. Ille modo per&#xA;2. Velant vultus et mente stipite simul&#xA;3. Iam locumque primo utrumque iussit in velle&#xA;4. Quaerant facies ne habemus coepto nec iras&#xA;&#xA;Cornum foribusque ambrosia fore fugit candida tum tecto mearum montes nascendi.&#xA;Et cuius. Tauri urbe numquam sors credensque placidissime coepit quoque cupidine&#xA;quem quos lapillis Itys.&#xA;--&gt;</description>
-    </item>
-    <item>
-      <title>Robust Autonomous Vehicles</title>
-      <link>https://aiea-lab.github.io/project/robustavs/</link>
-      <pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/project/robustavs/</guid>
-      <description>&lt;p&gt;Autonomous Vehicles (AVs), including aerial, ground, and sea vehicles, are becoming an integral part of our lives. Currently, most AVs trust sensor data to make navigation and other control decisions. In addition, they trust that the control commands given to actuators are executed faithfully. While trusting sensor and actuator data with minimal validation has proven to be an effective trade-off in current market solutions, it is not a sustainable practice as AVs become more pervasive and computer attacks increase in sophistication.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Separating facts and evaluation: motivation, account, and learnings from a novel approach to evaluating the human impacts of machine learning</title>
-      <link>https://aiea-lab.github.io/publication/separating-facts-and-evaluation-motivation-account-and-learnings-from-a-novel-approach-to-evaluating-the-human-impacts-of-machine-learning-2023/</link>
-      <pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/separating-facts-and-evaluation-motivation-account-and-learnings-from-a-novel-approach-to-evaluating-the-human-impacts-of-machine-learning-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>The anticipatory paradigm</title>
-      <link>https://aiea-lab.github.io/publication/the-anticipatory-paradigm-2023/</link>
-      <pubDate>Thu, 29 Jun 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/the-anticipatory-paradigm-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Anticipatory thinking challenges in open worlds: Risk management</title>
-      <link>https://aiea-lab.github.io/publication/anticipatory-thinking-challenges-in-open-worlds-risk-management-2023/</link>
-      <pubDate>Thu, 22 Jun 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/anticipatory-thinking-challenges-in-open-worlds-risk-management-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Masters</title>
-      <link>https://aiea-lab.github.io/alumni/john/</link>
-      <pubDate>Thu, 01 Jun 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/john/</guid>
-      <description>&lt;p&gt;John Yu is a Master&amp;rsquo;s Student in the Department of Computer Science and Engineering at UC Santa Cruz. His areas of technical interest are autonomous driving and embedded systems. In his spare time, John enjoys going to the gym, learning musical instruments, and cooking.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Ph.D. student</title>
-      <link>https://aiea-lab.github.io/member/li/</link>
-      <pubDate>Fri, 26 May 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/li/</guid>
-      <description>&lt;p&gt;Li is a third-year Ph.D. student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. He has a broad interest in Information Interpretation and Structuring, and Improving Accessibility with Assistive Technologies. Outside of his studies, Li enjoys cooking, photography, and painting.&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;https://leolee7.github.io/&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>The XAISuite framework and the implications of explanatory system dissonance</title>
-      <link>https://aiea-lab.github.io/publication/the-xaisuite-framework-and-the-implications-of-explanatory-system-dissonance-2023/</link>
-      <pubDate>Sat, 15 Apr 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/the-xaisuite-framework-and-the-implications-of-explanatory-system-dissonance-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Master student</title>
-      <link>https://aiea-lab.github.io/alumni/suma/</link>
-      <pubDate>Sat, 01 Apr 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/suma/</guid>
-      <description>&lt;p&gt;Kalyana Suma Sree Tholeti is an Masters student in the Department of&#xA;Computer Science and Engineering at UC Santa Cruz.  Her research&#xA;focuses on the XAI, Responsible data Science, and Generative AI. Her current work&#xA;is on developing a comprehensive model explanation monitoring framework within the manufacturing domain.&#xA;Her previous work is on analysis of bias in the knowledge-distilled models and Sentiment analysis.&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;//github.com/ktholeti&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;&#xA;&lt;!-- You can write $\LaTeX$ and *Markdown* here.&#xA;&#xA;# Minyae adgnoscitque fugiebat parentis ausum superos huius&#xA;&#xA;## Ait erili meruisse iactatis omnibus erat&#xA;&#xA;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse **mira mortisque leones**! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert *magno*, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&#xA;&#xA;&gt; Ultusque saltem crimine palluit virgineos deum nec pectusque oculis [que quos&#xA;&gt; lactea](http://habenas.com/.php) quae? Animus feriendus ductae! *Theron* sua&#xA;&gt; amans, est nulla cadavera, aquarum servavit quoque missus, hac texit videre,&#xA;&gt; valuere est erant? --&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate Student</title>
-      <link>https://aiea-lab.github.io/alumni/shreedhar/</link>
-      <pubDate>Mon, 27 Mar 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/shreedhar/</guid>
-      <description>&lt;p&gt;Shreedhar Jangam is an undergraduate student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His current research focuses on the applications of generative and explainable systems, such as Large Language Models and their trustworthiness in various domains. Outside of research, Shreedhar enjoys backpacking, and practicing his wilderness EMT skills.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Semi-Automated Synthesis of Driving Rules</title>
-      <link>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2023/</link>
-      <pubDate>Sun, 01 Jan 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2023/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Semi-Automated Synthesis of Driving Rules</title>
-      <link>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2024/</link>
-      <pubDate>Sun, 01 Jan 2023 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2024/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>A Framework for Generating Dangerous Scenes for Testing Robustness</title>
-      <link>https://aiea-lab.github.io/publication/a-framework-for-generating-dangerous-scenes-for-testing-robustness-2022/</link>
-      <pubDate>Wed, 23 Nov 2022 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/a-framework-for-generating-dangerous-scenes-for-testing-robustness-2022/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>DANGER: A Framework of Danger-Aware Novel Dataset Generator Extension for Robustness Test of Machine Learning</title>
-      <link>https://aiea-lab.github.io/publication/danger/</link>
-      <pubDate>Wed, 23 Nov 2022 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/danger/</guid>
-      <description>&lt;!--&#xA;You can add information in $\LaTeX$ and *Markdown* here.&#xA;--&gt;</description>
-    </item>
-    <item>
-      <title>Establishing meta-decision-making for AI: an ontology of relevance, representation and reasoning</title>
-      <link>https://aiea-lab.github.io/publication/establishing-meta-decision-making-for-ai-an-ontology-of-relevance-representation-and-reasoning-2022/</link>
-      <pubDate>Sun, 02 Oct 2022 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/establishing-meta-decision-making-for-ai-an-ontology-of-relevance-representation-and-reasoning-2022/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Master&#39;s Student</title>
-      <link>https://aiea-lab.github.io/member/batuhan/</link>
-      <pubDate>Sat, 17 Sep 2022 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/batuhan/</guid>
-      <description>&lt;p&gt;Batuhan is a first-year Master&amp;rsquo;s student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His research interests include applying deep reinforcement learning to Pacman and integrating explainable AI into the autograder system to provide real-time, detailed feedback to students. Outside of his studies, Batu enjoys workingout, playing basketball, gaming, and food (both cooking and eating).&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>&#39;Explanation&#39; is Not a Technical Term: The Problem of Ambiguity in XAI</title>
-      <link>https://aiea-lab.github.io/publication/explanation-is-not-a-technical-term-the-problem-of-ambiguity-in-xai-2022/</link>
-      <pubDate>Mon, 27 Jun 2022 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/explanation-is-not-a-technical-term-the-problem-of-ambiguity-in-xai-2022/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>Outracing champion Gran Turismo drivers with deep reinforcement learning</title>
-      <link>https://aiea-lab.github.io/publication/outracing-champion-gran-turismo-drivers-with-deep-reinforcement-learning-2022/</link>
-      <pubDate>Thu, 10 Feb 2022 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/publication/outracing-champion-gran-turismo-drivers-with-deep-reinforcement-learning-2022/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>MS at UCSC</title>
-      <link>https://aiea-lab.github.io/alumni/shengjie/</link>
-      <pubDate>Fri, 01 Oct 2021 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/shengjie/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title>PI</title>
-      <link>https://aiea-lab.github.io/member/leilani/</link>
-      <pubDate>Fri, 01 Oct 2021 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/member/leilani/</guid>
-      <description>&lt;p&gt;Leilani H. Gilpin is an Assistant Professor in the Department of&#xA;Computer Science and Engineering at UC Santa Cruz.  Her research&#xA;focuses on the design and analysis of methods for autonomous systems&#xA;to explain themselves.  Her work has applications to robust&#xA;decision-making, system debugging, and accountability.  Her current&#xA;work examines how generative models can be used in iterative XAI&#xA;stress testing.&lt;/p&gt;&#xA;&lt;p&gt;She holds a PhD in Computer Science from MIT, an M.S. in Computational&#xA;and Mathematical Engineering from Stanford University, and a B.S. in&#xA;Mathematics (with honors), B.S. in Computer Science (with highest&#xA;honors), and a music minor from UC San Diego.  Outside of research,&#xA;Leilani enjoys swimming, cooking, hiking, and org-mode.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Undergraduate student</title>
-      <link>https://aiea-lab.github.io/alumni/tong/</link>
-      <pubDate>Thu, 11 Mar 2021 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/alumni/tong/</guid>
-      <description>&lt;p&gt;Tong is a 4th-year undergraduate student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His research interests are Artificial Intelligence, Machine Learning, Natural Language Processing / Large Language Models ,and Computer Vision.&#xA;Outside of Classroom, Tong enjoys badminton, ping-pong, e-sports and Shōgi(Japanese Chess)&#xA;(Tong is currently applying to Master&amp;rsquo;s program for 2024 Fall)&lt;/p&gt;&#xA;&lt;ul&gt;&#xA;&lt;li&gt;Captain of Team China at World Shōgi League Since 2022&lt;/li&gt;&#xA;&lt;li&gt;🥉3rd place, 2022 Hearthstone Collegiate Masters Champions&lt;/li&gt;&#xA;&lt;li&gt;6th place, Fall 2022 Hearthstone Collegiate Masters&lt;/li&gt;&#xA;&lt;li&gt;🏆1st place award at the 2019 North America Shōgi Tournament, Adolescent Division&lt;/li&gt;&#xA;&lt;/ul&gt;</description>
-    </item>
-    <item>
-      <title>Deep Learning</title>
-      <link>https://aiea-lab.github.io/join/deeplearning/</link>
-      <pubDate>Tue, 12 Jul 2016 16:10:22 +0200</pubDate>
-      <guid>https://aiea-lab.github.io/join/deeplearning/</guid>
-      <description>&lt;h1 id=&#34;et-sensus-uncos-troiaeque-mori-candidaque-ostentis&#34;&gt;Et sensus uncos Troiaeque mori candidaque ostentis&lt;/h1&gt;&#xA;&lt;h2 id=&#34;litusque-praemia&#34;&gt;Litusque praemia&lt;/h2&gt;&#xA;&lt;p&gt;&lt;em&gt;Lorem markdownum&lt;/em&gt; natus, regis cecidere. Sinebat pudoris terque si commune&#xA;pendebat ubi dubio cibique pontum virentem Nestora gaudia decebat &lt;a href=&#34;http://inarmis.net/.html&#34;&gt;quoniam&#xA;eunt&lt;/a&gt;: graves.&#xA;&lt;a href=&#34;http://www.autumni-remissis.io/ab&#34;&gt;Teleste&lt;/a&gt; est colebat iamque ullis terra&#xA;neque limen Nabataeus viribus ait.&lt;/p&gt;&#xA;&lt;pre&gt;&lt;code&gt;encoding_install_autoresponder = ultra.osiComputer(host.ccdColdWddm(fsb,&#xA;        compressionAlignment), 324317, adsl_application);&#xA;if (exbibyte(remoteCopy.pplVirtualUrl(3, hardOopBoot), solid, 46)) {&#xA;    eide_podcast(trinitron.statusRawApple(class, cmyk_gigabit));&#xA;    ddrEcc(maximizeRw, appletPersonal);&#xA;    hdd_null = pretest_window_rup;&#xA;} else {&#xA;    system += hdd + 396409 - firewallLanMedia;&#xA;}&#xA;var firmware_wan = api(boot_winsock_us, 1, domainNetbios) + web_veronica_sql&#xA;        + javascriptCtrPppoe.balancing(smtp, 1);&#xA;&lt;/code&gt;&lt;/pre&gt;&#xA;&lt;h2 id=&#34;reperire-haec-iunone-dolor-talaria-eque-maesto&#34;&gt;Reperire haec Iunone dolor talaria eque maesto&lt;/h2&gt;&#xA;&lt;p&gt;Letalem et nomen animalia summaque. Vivit et regione bracchia cui prosiliunt&#xA;videat; sol cuius inquit siquid est labens, nomina? Alcimedon nomine spectarat.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Wide Learning</title>
-      <link>https://aiea-lab.github.io/join/widelearning/</link>
-      <pubDate>Tue, 12 Jul 2016 16:10:22 +0200</pubDate>
-      <guid>https://aiea-lab.github.io/join/widelearning/</guid>
-      <description>&lt;h1 id=&#34;et-sensus-uncos-troiaeque-mori-candidaque-ostentis&#34;&gt;Et sensus uncos Troiaeque mori candidaque ostentis&lt;/h1&gt;&#xA;&lt;h2 id=&#34;litusque-praemia&#34;&gt;Litusque praemia&lt;/h2&gt;&#xA;&lt;p&gt;&lt;em&gt;Lorem markdownum&lt;/em&gt; natus, regis cecidere. Sinebat pudoris terque si commune&#xA;pendebat ubi dubio cibique pontum virentem Nestora gaudia decebat &lt;a href=&#34;http://inarmis.net/.html&#34;&gt;quoniam&#xA;eunt&lt;/a&gt;: graves.&#xA;&lt;a href=&#34;http://www.autumni-remissis.io/ab&#34;&gt;Teleste&lt;/a&gt; est colebat iamque ullis terra&#xA;neque limen Nabataeus viribus ait.&lt;/p&gt;&#xA;&lt;pre&gt;&lt;code&gt;encoding_install_autoresponder = ultra.osiComputer(host.ccdColdWddm(fsb,&#xA;        compressionAlignment), 324317, adsl_application);&#xA;if (exbibyte(remoteCopy.pplVirtualUrl(3, hardOopBoot), solid, 46)) {&#xA;    eide_podcast(trinitron.statusRawApple(class, cmyk_gigabit));&#xA;    ddrEcc(maximizeRw, appletPersonal);&#xA;    hdd_null = pretest_window_rup;&#xA;} else {&#xA;    system += hdd + 396409 - firewallLanMedia;&#xA;}&#xA;var firmware_wan = api(boot_winsock_us, 1, domainNetbios) + web_veronica_sql&#xA;        + javascriptCtrPppoe.balancing(smtp, 1);&#xA;&lt;/code&gt;&lt;/pre&gt;&#xA;&lt;h2 id=&#34;reperire-haec-iunone-dolor-talaria-eque-maesto&#34;&gt;Reperire haec Iunone dolor talaria eque maesto&lt;/h2&gt;&#xA;&lt;p&gt;Letalem et nomen animalia summaque. Vivit et regione bracchia cui prosiliunt&#xA;videat; sol cuius inquit siquid est labens, nomina? Alcimedon nomine spectarat.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/about/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/about/</guid>
-      <description>&lt;h1 id=&#34;sed-extemplo-conantur-et-cnosia-harundine-lyra&#34;&gt;Sed extemplo conantur et Cnosia harundine lyra&lt;/h1&gt;&#xA;&lt;h2 id=&#34;agros-metitur-venatibus-catenis-quippe-honorem-tuorum&#34;&gt;Agros metitur venatibus catenis quippe honorem tuorum&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum finemque prunaque longe et sunt. Sed super aulaea in Paridis&#xA;noctisque cubile? Iacit coetus, vastatoremque dedit; Vidi magna, recurvatis&#xA;copia. Quod sit; per cingo tamen Hyperionis si vacat &lt;strong&gt;inclitus&lt;/strong&gt; instabat&#xA;curaque arma saxea, naturaeque pondere quaeque aer!&lt;/p&gt;&#xA;&lt;ol&gt;&#xA;&lt;li&gt;Agros apertum aliis dominaeque rapidus&lt;/li&gt;&#xA;&lt;li&gt;Prima nulla est&lt;/li&gt;&#xA;&lt;li&gt;Hortatibus voto&lt;/li&gt;&#xA;&lt;/ol&gt;&#xA;&lt;h2 id=&#34;anum-istis-praefertur-est&#34;&gt;Anum istis praefertur est&lt;/h2&gt;&#xA;&lt;p&gt;Quaque coeptis lumina mea nuda dentes semine agitavit, caesique voluptas. Proque&#xA;priori vultus est colle fuit manet manibusque Liber vulnus famulosque memorante&#xA;dari. Aut quod ergo, oris simulasse. Ministros cogeret momordit aut tibi, posita&#xA;non inhaesit sede vulnera sontes Phoebeos, faenilibus non rursus.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/approach/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/approach/</guid>
-      <description>&lt;h1 id=&#34;et-malis-vellet-tellus-deseruere-in-credant&#34;&gt;Et malis vellet tellus deseruere in credant&lt;/h1&gt;&#xA;&lt;h2 id=&#34;inde-sidera-moenia-lacertis-nomen-nostra-membra&#34;&gt;Inde sidera moenia lacertis nomen nostra membra&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum miranti. Sonus faciunt omnibus frustra: illa possem ad regio&#xA;Anubis tamen. Sustulerat debent fluviis herbis attollere rogus et formae&#xA;nitentem avellere motis clipeus Achilles felix videam undas. &lt;em&gt;Posuit haec ipse&lt;/em&gt;&#xA;posse.&lt;/p&gt;&#xA;&lt;p&gt;Ore fame mons Olympi tantae &lt;em&gt;stringit&lt;/em&gt; columbas proxima habebat, longius alta&#xA;non. Haeserat gerunt detinuit genis est huc, dixit tam dumque nitidum.&lt;/p&gt;&#xA;&lt;ol&gt;&#xA;&lt;li&gt;Cristata causam Triones moenia habentem subito utentem&lt;/li&gt;&#xA;&lt;li&gt;Astraea castris contentus nisi leve eum invia&lt;/li&gt;&#xA;&lt;li&gt;Inferiusque capta cognoscenda flaventi locuta notavi fallere&lt;/li&gt;&#xA;&lt;li&gt;Moriens scripsi ictus tuo cum&lt;/li&gt;&#xA;&lt;/ol&gt;&#xA;&lt;p&gt;Tarpeias insurgens summo sinistra vertice, in neve utroque exempla Cyparissus&#xA;tanta tecti terras. Dextras superest flammis accipe volatu vulneris indomitae&#xA;unguibus insignia tempora aquas.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/auditor/allan_dewey/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/auditor/allan_dewey/</guid>
-      <description></description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/join/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/join/</guid>
-      <description>&lt;h1 id=&#34;join-us&#34;&gt;Join us!&lt;/h1&gt;&#xA;&lt;p&gt;Currently, the AIEA lab is at &lt;em&gt;capacity&lt;/em&gt; and not seeking new students&#xA;to join at this time.  We will update this page as openings become&#xA;available.&lt;/p&gt;&#xA;&lt;p&gt;Interested students are welcome to complete the lab interest &lt;a href=&#34;https://forms.gle/CpmrgSxGSUvDWo3J7&#34;&gt;form&lt;/a&gt;.&#xA;We examine new applicants at the start of each academic quarter (excluding summer).&lt;/p&gt;&#xA;&lt;h2 id=&#34;prospective-phd-students&#34;&gt;Prospective PhD students&lt;/h2&gt;&#xA;&lt;!-- The AIEA group takes on 0-2 new PhD students each year.--&gt;&#xA;&lt;p&gt;For the 2025-2026 academic year, due to the group size and uncertainty of research funds, we are not recruiting PhD students.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/mission/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/mission/</guid>
-      <description>&lt;h1 id=&#34;auras-queritur-facientes-dixit-venti-sustinui&#34;&gt;Auras queritur facientes dixit venti sustinui&lt;/h1&gt;&#xA;&lt;h2 id=&#34;e-in-mora&#34;&gt;E in mora&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum poenaque nuper destituit silendo quoniam, nec ait consorte&#xA;membra, figuram hanc cum. Manifesta vitae facies exiguumque iunctam dictis.&#xA;Vidit eadem, hanc cum descendit &lt;strong&gt;sinu&lt;/strong&gt; misit quem fecit, positisque pastorve.&#xA;Missus solos &lt;em&gt;potentia in&lt;/em&gt; erant noctem est!&lt;/p&gt;&#xA;&lt;pre&gt;&lt;code&gt;if (dvdProcessorVolume &amp;lt; mpegProcess(slashdot, gigahertz)) {&#xA;    transferAnsiBotnet.and(logSoftware, hsfClipboardSubnet.queue_publishing(&#xA;            systemMemory, 5, yahoo));&#xA;} else {&#xA;    swappableIpv -= spoolingAdwareCrossplatform;&#xA;    extranetAppArchitecture(1, dtd_rpc_font(45, 67, development_sli));&#xA;}&#xA;antivirus_ipv = touchscreenFiosGrep.portIcsDrive(zone_vista);&#xA;bootExpression = 2 * sprite_dv + apache;&#xA;if (cifsZone(status) &amp;gt; wddm_cifs) {&#xA;    disk_access_www.halftone_plagiarism = 4;&#xA;} else {&#xA;    domainFat(vectorCdnMalware, -2, hard.smartphone_e_wep(phreaking_memory,&#xA;            5, kerningError));&#xA;    address += troubleshooting;&#xA;    rdramRegistry(printerHoc);&#xA;}&#xA;&lt;/code&gt;&lt;/pre&gt;&#xA;&lt;p&gt;Ipsa namque impetus crinem nefandas, parant inmensum noviens specie vita. Ire&#xA;locus quietis, amata occiderat Achaidas cervum quos pavit dissiluit an&#xA;&lt;a href=&#34;http://artenitido.org/non.html&#34;&gt;loqui&lt;/a&gt; consolantia fontes; &lt;em&gt;tenus quae&lt;/em&gt;. Facit&#xA;verumque per Pindusque paelice inmensi: vino exire, fuisse munera. Quam pars&#xA;quod gravidi pennas: non illa et senex, et Iunone.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title></title>
-      <link>https://aiea-lab.github.io/vacancy/vacancy1/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/vacancy/vacancy1/</guid>
-      <description>&lt;p&gt;You can write $\LaTeX$ and &lt;em&gt;Markdown&lt;/em&gt; here.&lt;/p&gt;&#xA;&lt;h1 id=&#34;minyae-adgnoscitque-fugiebat-parentis-ausum-superos-huius&#34;&gt;Minyae adgnoscitque fugiebat parentis ausum superos huius&lt;/h1&gt;&#xA;&lt;h2 id=&#34;ait-erili-meruisse-iactatis-omnibus-erat&#34;&gt;Ait erili meruisse iactatis omnibus erat&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse &lt;strong&gt;mira mortisque leones&lt;/strong&gt;! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert &lt;em&gt;magno&lt;/em&gt;, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&lt;/p&gt;</description>
-    </item>
-    <item>
-      <title>Research</title>
-      <link>https://aiea-lab.github.io/research/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://aiea-lab.github.io/research/</guid>
-      <description>&lt;p&gt;Learn more about our &lt;a href=&#34;https://aiea-lab.github.io/project/&#34;&gt;active projects&lt;/a&gt; and if you are interested, see about &lt;a href=&#34;https://aiea-lab.github.io/join/&#34;&gt;joining us&lt;/a&gt;.&lt;/p&gt;&#xA;&lt;p&gt;Coming soon!&lt;/p&gt;&#xA;&lt;h1 id=&#34;funding&#34;&gt;Funding&lt;/h1&gt;&#xA;&lt;p&gt;Our research is generously supported by the Underwriters Labatory (subaward from Northwestern University), UC Santa Cruz Seed Funding, Department of Transportation, and Siemens.&lt;/p&gt;&#xA;&lt;!--# Modo est&#xA;&#xA;## Non sub haedum tenet&#xA;&#xA;Lorem markdownum esse diversa quoque vocavit, quam! Vires tibi axis dum spolium&#xA;*vaticinor fulminis*, a dixere attrahit generisque tamen?&#xA;&#xA;- Petit invergens iram praetendat iam&#xA;- Mecum res curva iunctura silvis hoc leonum&#xA;- Iacent gemitum quos&#xA;&#xA;## Non est duram mitis sonat proculcat tumulos&#xA;&#xA;Alce bimembres Dauni, cur ex voces referam adunco in sors. Manibusque poples&#xA;prodidit lata tantum quem suos ratae Aeginae sederunt degenerat Bacchus&#xA;descendere, patriisque ieiunia.&#xA;&#xA;## Harenas sanguine pennas fui&#xA;&#xA;Gentes aeris, sua mors dictis torvo colorem regione fugit principio Panopeusque&#xA;regni florentis vidisse. [Profusis](http://motu-tutus.io/exerceor-vestigia.php)&#xA;unda regnat ultima habitus cava tympana sudem et Aesonides fecit. Pondere visa&#xA;stant comitavit, et parente umida contentis divumque *sospes non* facinus arma&#xA;sed quamvis vectus. Fera nec uno erat, poterat censu nitebat, cognita simulacra?&#xA;Fumis patuisset tantum et tanta ad matris enodisque vestros exigui.&#xA;&#xA;&gt; Tamen coniectum sumpserat comites dura, amore exanimes iussit At? Cuncta&#xA;&gt; tellus ad turbine lupos. Querentes Ulixes rivus Thetis fraternaque adimunt,&#xA;&gt; sex vivacem, excepit potuit meruique, at tutos.&#xA;&#xA;## Diversaque Medusae probatur sequens&#xA;&#xA;Ea pruinosas verba lapidem, sustulit. Una quicquam nymphis adultera&#xA;[maturus](http://www.corripuere.net/toto) fuimusve lumina occidimus subiti&#xA;demoliturque pelagi.&#xA;&#xA;Satis omni hunc et quondam non, non curat adlabimur? Vocem oves curvum aptumque.&#xA;Addendum tamen; parensque multi locum palmas tenent dubites sacra! Autem de quem&#xA;autumnum cornu Echione Esse colebatur quodsi dextera perdidit rescierit coniuge,&#xA;conata, manent omnia. Illa est fecerat nubila vix semel tetigere sit sine&#xA;inguina.&#xA;--&gt;</description>
-    </item>
-  </channel>
+	<channel>
+		<title>AIEA Lab</title>
+		<link>https://aiea-lab.github.io/</link>
+		<description>Recent content on AIEA Lab</description>
+		<generator>Hugo</generator>
+		<language>en</language>
+		
+		
+		
+			<copyright>&amp;copy; AIEA Lab, 2023 </copyright>
+		
+		
+			<lastBuildDate>Fri, 15 May 2026 00:00:00 +0000</lastBuildDate>
+		
+			<atom:link href="https://aiea-lab.github.io/index.xml" rel="self" type="application/rss+xml" />
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/lucy_h/</link>
+				<pubDate>Fri, 15 May 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/lucy_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/shefali/</link>
+				<pubDate>Fri, 01 May 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/shefali/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/bhoomika/</link>
+				<pubDate>Mon, 06 Apr 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/bhoomika/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>UnderGrad</title>
+				<link>https://aiea-lab.github.io/auditor/surya_raja/</link>
+				<pubDate>Fri, 03 Apr 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/surya_raja/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/sanya_b/</link>
+				<pubDate>Fri, 03 Apr 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sanya_b/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/tanvibellibelli/</link>
+				<pubDate>Fri, 03 Apr 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tanvibellibelli/</guid>
+				<description>&lt;p&gt;Hello! My name is Tanvi Belli Belli, and I am a sophomore majoring in Technology Information Management. I am also working towards a minor in Computer Science as well. I am excited in contributing to the AIEA Lab and working on the LLM Logic Project!&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/ruhan_gianchandani/</link>
+				<pubDate>Thu, 02 Apr 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ruhan_gianchandani/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/haatim_ali/</link>
+				<pubDate>Wed, 01 Apr 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/haatim_ali/</guid>
+				<description>&lt;p&gt;I am a first year proposed Computer Science major interested in Artificial Intelligence and Machine Learning. I love playing soccer, going on hikes, and hanging out with friends.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/bowie_c/</link>
+				<pubDate>Wed, 01 Apr 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/bowie_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/samanyukumar/</link>
+				<pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/samanyukumar/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/alexander_smolyanskiy/</link>
+				<pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/alexander_smolyanskiy/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/anthony/</link>
+				<pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/anthony/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/daniel_dubiner/</link>
+				<pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/daniel_dubiner/</guid>
+				<description>&lt;p&gt;I like video games, board games, and D&amp;amp;D.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/dylan_price/</link>
+				<pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/dylan_price/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate </title>
+				<link>https://aiea-lab.github.io/auditor/utkarshbanka/</link>
+				<pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/utkarshbanka/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate Student</title>
+				<link>https://aiea-lab.github.io/auditor/ran_chen/</link>
+				<pubDate>Tue, 31 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ran_chen/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/daniel_hong/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/daniel_hong/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/prateek_gupta/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/prateek_gupta/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/abhyuthoppae/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/abhyuthoppae/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/aryanbhatia/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/aryanbhatia/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/ember_lu/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ember_lu/</guid>
+				<description>&lt;p&gt;Ember is a second-year Computer Science student. Her background is in AI pipelines, full-stack, and research in neural networks, computational ecology, and molecular dynamics. Her passions are swimming, 3D printing, baking, and customizing mechanical keyboards.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/hyerin/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/hyerin/</guid>
+				<description>&lt;p&gt;I am an undergraduate student from Yonsei University currently studying as an exchange student at UC Santa Cruz. My research interests include AI systems, database systems, and computer architecture. I am particularly interested in system-level optimization and efficient computing for large-scale applications.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/naga/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/naga/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>UnderGraduate</title>
+				<link>https://aiea-lab.github.io/auditor/larsvoigt-bui/</link>
+				<pubDate>Mon, 30 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/larsvoigt-bui/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/caitelyn/</link>
+				<pubDate>Sun, 29 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/caitelyn/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/navaneeth/</link>
+				<pubDate>Fri, 20 Mar 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/navaneeth/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/mayank/</link>
+				<pubDate>Wed, 04 Feb 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/mayank/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/adithi/</link>
+				<pubDate>Fri, 23 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/adithi/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/haardhik_ma/</link>
+				<pubDate>Sun, 18 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/haardhik_ma/</guid>
+				<description>&lt;p&gt;authors = []&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/gaurijain/</link>
+				<pubDate>Tue, 13 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/gaurijain/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/anishbansal/</link>
+				<pubDate>Tue, 13 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/anishbansal/</guid>
+				<description>&lt;p&gt;.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/raunak_anwar/</link>
+				<pubDate>Tue, 13 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/raunak_anwar/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/sashreek/</link>
+				<pubDate>Mon, 12 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sashreek/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/chanchal/</link>
+				<pubDate>Sat, 10 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/chanchal/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/ron/</link>
+				<pubDate>Thu, 08 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ron/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/aneshkondor/</link>
+				<pubDate>Thu, 08 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/aneshkondor/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/jacob_wei/</link>
+				<pubDate>Thu, 08 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/jacob_wei/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/omer_boztepe/</link>
+				<pubDate>Wed, 07 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/omer_boztepe/</guid>
+				<description>&lt;p&gt;Put your bio here.&#xA;My name is Omer Boztepe. I am a 4th year CS major at UCSC.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergradute</title>
+				<link>https://aiea-lab.github.io/auditor/marco/</link>
+				<pubDate>Wed, 07 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/marco/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Student</title>
+				<link>https://aiea-lab.github.io/auditor/riddhi/</link>
+				<pubDate>Tue, 06 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/riddhi/</guid>
+				<description>&lt;p&gt;Hi, my name is Riddhi Mundhra. I am a third-year UCSC Computer Science (Game Design) and Computer Engineering student. I am interested in AI/ML, autonomous vehicles, game development, and full-stack software projects.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/ashwin_vinod/</link>
+				<pubDate>Tue, 06 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ashwin_vinod/</guid>
+				<description>&lt;p&gt;Hey, my name is Ashwin! I&amp;rsquo;m a 2nd year computer science major at UCSC. I&amp;rsquo;m interested in procedural content generation, and neural networks.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/sree_gudapati/</link>
+				<pubDate>Tue, 06 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sree_gudapati/</guid>
+				<description>&lt;p&gt;I am a Computer Science Student at UC Santa Cruz with a passion for computer vision, machine learning, and full-stack development. Currently, I am participating in a project with Slugbotics , where I am working on integrating neural networks into autonomous systems for road hazard detection . As an aspiring Software Engineer, I am dedicated to applying these technical skills to solve complex, real-world problems&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/vseslav/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/vseslav/</guid>
+				<description>&lt;p&gt;Vseslav Kazakov (Vee for short) is a Computer Science Game Design Student at UC Santa Cruz interested in low level programming and AI research. Vee joined the AIEA lab Winter 2026 to work on Autonomous vehicles research.&lt;/p&gt;&#xA;&lt;!-- You can write $\LaTeX$ and *Markdown* here.&#xA;&#xA;# Minyae adgnoscitque fugiebat parentis ausum superos huius&#xA;&#xA;## Ait erili meruisse iactatis omnibus erat&#xA;&#xA;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse **mira mortisque leones**! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert *magno*, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&#xA;&#xA;&gt; Ultusque saltem crimine palluit virgineos deum nec pectusque oculis [que quos&#xA;&gt; lactea](http://habenas.com/.php) quae? Animus feriendus ductae! *Theron* sua&#xA;&gt; amans, est nulla cadavera, aquarum servavit quoque missus, hac texit videre,&#xA;&gt; valuere est erant? --&gt;</description>
+			</item>
+			<item>
+				<title>undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/mandy_wu/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/mandy_wu/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/anurag_n/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/anurag_n/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/ashwin_senthilvasan/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ashwin_senthilvasan/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/collin/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/collin/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/crystal/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/crystal/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/idohaiby/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/idohaiby/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/justin_r/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/justin_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/nathan_yee/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/nathan_yee/</guid>
+				<description>&lt;p&gt;Computer Engineering student passionate about building intelligent systems at the intersection of software and hardware. I bring strong skills in machine learning, systems programming, algorithms, and autonomous systems development, with hands-on experience across the full technology stack. From low-level FPGA design to high-level AI applications. I thrive on solving complex technical problems and am particularly drawn to projects that combine analytical thinking with real-world impact.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/roshni_gundavelli/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/roshni_gundavelli/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/rudra_c/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/rudra_c/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/sergio_h/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sergio_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/tania/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tania/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate Student</title>
+				<link>https://aiea-lab.github.io/auditor/george/</link>
+				<pubDate>Mon, 05 Jan 2026 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/george/</guid>
+				<description>&lt;p&gt;Hello.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Guaranteed Optimal Compositional Explanations for Neurons</title>
+				<link>https://aiea-lab.github.io/publication/guaranteed-optimal-compositional-explanations-2025/</link>
+				<pubDate>Tue, 25 Nov 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/guaranteed-optimal-compositional-explanations-2025/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Open Vocabulary Compositional Explanations for Neuron Alignment</title>
+				<link>https://aiea-lab.github.io/publication/open-vocabulary-compositional-explanations-2025/</link>
+				<pubDate>Tue, 25 Nov 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/open-vocabulary-compositional-explanations-2025/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>member</title>
+				<link>https://aiea-lab.github.io/member/nazanin/</link>
+				<pubDate>Sun, 09 Nov 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/nazanin/</guid>
+				<description>&lt;p&gt;Nazanin is an independent researcher and a collaborator.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate Student</title>
+				<link>https://aiea-lab.github.io/auditor/victor/</link>
+				<pubDate>Sun, 19 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/victor/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/bardia/</link>
+				<pubDate>Sat, 18 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/bardia/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/naomi/</link>
+				<pubDate>Tue, 14 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/naomi/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/zaki/</link>
+				<pubDate>Tue, 14 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/zaki/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/ajmcdaniel/</link>
+				<pubDate>Sun, 12 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ajmcdaniel/</guid>
+				<description>&lt;p&gt;AJ McDaniel is an undergraduate Computer Science student at UC Santa Cruz and a member of the AIEA Lab, where he explores the intersection of artificial intelligence, software engineering, and human-centered design. His interests include explainable AI, responsible system design, and applications of machine learning in education and healthcare. AJ has experience as a Data &amp;amp; AI/ML Engineering Intern at ResMed and conducts research in runtime verification and trustworthy AI at the University of Illinois Urbana-Champaign. Outside of research, he leads student tech initiatives, mentors peers in programming and circuit design, and actively participates in hackathons and engineering outreach.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Follow My Lead: Logical Fallacy Classification with Knowledge-Augmented LLMs</title>
+				<link>https://aiea-lab.github.io/publication/follow-my-lead-logical-fallacy-classification-with-knowledge-augmented-llms-2025/</link>
+				<pubDate>Sat, 11 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/follow-my-lead-logical-fallacy-classification-with-knowledge-augmented-llms-2025/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/riya-narang/</link>
+				<pubDate>Fri, 10 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/riya-narang/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/tora_m/</link>
+				<pubDate>Fri, 10 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tora_m/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/member/caleb/</link>
+				<pubDate>Fri, 10 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/caleb/</guid>
+				<description>&lt;p&gt;Caleb Bergen is an undergraduate student at UC Santa Cruz majoring in Computer Science. His current work examines the effectiveness and ethics of using large language models (LLMs) as driving assistants for autonomous vehicles in simulations.&lt;/p&gt;&#xA;&lt;p&gt;Caleb holds an A.S. in Mathematics and an A.S. in Computer Science (both with highest honors) from Fresno City College. He transferred to UC Santa Cruz in the fall of 2024 and will be graduating in the spring 2026 quarter. His other hobbies including watching sports, playing board games, and walking around UC Santa Cruz&amp;rsquo;s beautiful campus.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>BS</title>
+				<link>https://aiea-lab.github.io/auditor/inikabhargava/</link>
+				<pubDate>Wed, 08 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/inikabhargava/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/jatikilt/</link>
+				<pubDate>Mon, 06 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/jatikilt/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate Researcher</title>
+				<link>https://aiea-lab.github.io/auditor/surya_jagarlamudi/</link>
+				<pubDate>Mon, 06 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/surya_jagarlamudi/</guid>
+				<description>&lt;p&gt;Surya Jagarlamudi is a Computer Engineering undergraduate at UC Santa Cruz focusing on artificial intelligence, computational modeling, and full-stack software systems. He is passionate about using technology to create adaptive, human-centered solutions in engineering and data-driven decision making.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Explore the Loss space with Hill-ADAM</title>
+				<link>https://aiea-lab.github.io/publication/explore-the-loss-space-with-hill-adam-2025/</link>
+				<pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/explore-the-loss-space-with-hill-adam-2025/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/pravin/</link>
+				<pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/pravin/</guid>
+				<description>&lt;p&gt;&amp;ldquo;3rd year Computer Engineering student at UC Santa Cruz excited to explore the edges of AI and expand the frontier&amp;rdquo;&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergradute</title>
+				<link>https://aiea-lab.github.io/auditor/dheshnaa_madasamy/</link>
+				<pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/dheshnaa_madasamy/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergradute</title>
+				<link>https://aiea-lab.github.io/auditor/farhan_ali/</link>
+				<pubDate>Sat, 04 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/farhan_ali/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/arnav_d/</link>
+				<pubDate>Thu, 02 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/arnav_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/jesus_cuevas/</link>
+				<pubDate>Thu, 02 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/jesus_cuevas/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/siddharth_m/</link>
+				<pubDate>Wed, 01 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/siddharth_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/parsh_gandhi/</link>
+				<pubDate>Wed, 01 Oct 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/parsh_gandhi/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/anurag_c/</link>
+				<pubDate>Tue, 30 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/anurag_c/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/jaisree/</link>
+				<pubDate>Tue, 30 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/jaisree/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/pujitha/</link>
+				<pubDate>Tue, 30 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/pujitha/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/trisha_moorkoth/</link>
+				<pubDate>Tue, 30 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/trisha_moorkoth/</guid>
+				<description>&lt;p&gt;Hi I&amp;rsquo;m Trisha! I&amp;rsquo;m a 4th year CS major interested in explainable AI and building educational tools!&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/amanvars/</link>
+				<pubDate>Mon, 29 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/amanvars/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/matthew_k/</link>
+				<pubDate>Mon, 29 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/matthew_k/</guid>
+				<description>&lt;p&gt;Matthew Kimotsuki is a 4th year computer science student at UCSC with an interest in AI safety and ethics.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate student</title>
+				<link>https://aiea-lab.github.io/auditor/dongjun_h/</link>
+				<pubDate>Mon, 29 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/dongjun_h/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>VFSI: Validity First Spatial Intelligence for Constraint-Guided Traffic Diffusion</title>
+				<link>https://aiea-lab.github.io/publication/vfsi-validity-first-spatial-intelligence-for-constraint-guided-traffic-diffusion-2025/</link>
+				<pubDate>Sun, 28 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/vfsi-validity-first-spatial-intelligence-for-constraint-guided-traffic-diffusion-2025/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>NeSy Law</title>
+				<link>https://aiea-lab.github.io/project/nesylaw/</link>
+				<pubDate>Sat, 27 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/project/nesylaw/</guid>
+				<description>&lt;p&gt;The NeSy (previously known as LLM + Law) project focuses on harvesting the power of symbolic language and Neuro-symbolic AI for legal use cases.&#xA;Neuro-symbolic AI (also known as NeSy) is a field that combines the generalizability of Neural Networks and interpretability and control of Symbolic AI. The highly structured setup with potential capability for formal verification is a great fit for the legal field. Its generalizability is promising to lift up the burden of heavy legal document review and drafting&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Neuron Explanations</title>
+				<link>https://aiea-lab.github.io/project/neuron_expl/</link>
+				<pubDate>Sat, 27 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/project/neuron_expl/</guid>
+				<description>&lt;p&gt;The Neuron Explanation project aims to understand what deep neural networks (CNN, LLMs) learn during the training process by analyzing what individual neurons are able to recognize in terms of concepts (e.g., cat, building, etc). Specifically, we aim to achieve this goal by associating logical rules (e.g., (Cat OR Dog) AND NOT person)) to each neuron that express the (spatial) alignment between neurons activations and concept locations. These rules are usually extracted by combining search algorithms, clustering algorithms and statistical analysis of neurons activation.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/andre_chen/</link>
+				<pubDate>Sat, 27 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/andre_chen/</guid>
+				<description>&lt;p&gt;Putting bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/aman_avinash/</link>
+				<pubDate>Fri, 26 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/aman_avinash/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergrad Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/kkasturi/</link>
+				<pubDate>Tue, 23 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/kkasturi/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/evan_kaiden/</link>
+				<pubDate>Mon, 01 Sep 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/evan_kaiden/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/bhavyashanmugam/</link>
+				<pubDate>Thu, 07 Aug 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/bhavyashanmugam/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/bolor_b/</link>
+				<pubDate>Thu, 10 Jul 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/bolor_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/stanley/</link>
+				<pubDate>Thu, 10 Jul 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/stanley/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/pavithra/</link>
+				<pubDate>Thu, 08 May 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/pavithra/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Masters</title>
+				<link>https://aiea-lab.github.io/auditor/sameera_sk/</link>
+				<pubDate>Tue, 08 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sameera_sk/</guid>
+				<description>&lt;p&gt;I’m a curious human who loves two things: making AI make sense (hello, Explainable AI) and saving the planet (starting with climate change). With a background in software development, I enjoy building things that actually do something—ideally, something good.&lt;/p&gt;&#xA;&lt;p&gt;I spend my days learning how machines can understand the messy beauty of nature—and my weekends letting the ocean remind me how little I know. 🌊&lt;/p&gt;&#xA;&lt;p&gt;When I&amp;rsquo;m not working on clearer, smarter AI for climate science, you’ll find me surfing waves, scuba diving with fish, or just daydreaming about coral reefs. I believe the best ideas come from mixing data with saltwater and logic with a little chaos.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/divya_j/</link>
+				<pubDate>Thu, 03 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/divya_j/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/adam_m/</link>
+				<pubDate>Wed, 02 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/adam_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/michael_zhou/</link>
+				<pubDate>Wed, 02 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/michael_zhou/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/koushik/</link>
+				<pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/koushik/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Masters</title>
+				<link>https://aiea-lab.github.io/member/charlie_a/</link>
+				<pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/charlie_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergrad Student</title>
+				<link>https://aiea-lab.github.io/auditor/shripad_m/</link>
+				<pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/shripad_m/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergrad Student, UCSC</title>
+				<link>https://aiea-lab.github.io/auditor/ash/</link>
+				<pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ash/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/tisha/</link>
+				<pubDate>Tue, 01 Apr 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tisha/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Lab Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/william_ho/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/william_ho/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergrad</title>
+				<link>https://aiea-lab.github.io/auditor/chris_camberos/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/chris_camberos/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergradguate</title>
+				<link>https://aiea-lab.github.io/auditor/suhani/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/suhani/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/neha_h/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/neha_h/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/member/jetha/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/jetha/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate Student</title>
+				<link>https://aiea-lab.github.io/auditor/harini/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/harini/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate Student</title>
+				<link>https://aiea-lab.github.io/auditor/nickolas_t/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/nickolas_t/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate Student</title>
+				<link>https://aiea-lab.github.io/auditor/yashas/</link>
+				<pubDate>Mon, 31 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/yashas/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/satvik_k/</link>
+				<pubDate>Sat, 01 Mar 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/satvik_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/rami_al_habash/</link>
+				<pubDate>Sat, 11 Jan 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/rami_al_habash/</guid>
+				<description>&lt;p&gt;I am an undergraduate student at UCSC researching AI Explainability and Accountability. I am also a part-time Code Coach. I&amp;rsquo;m also a big soccer fan! For any inquiries, feel free to reach me at the email above.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Auditor</title>
+				<link>https://aiea-lab.github.io/auditor/kunwarpalsingh/</link>
+				<pubDate>Sun, 05 Jan 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/kunwarpalsingh/</guid>
+				<description>&lt;p&gt;Hi, my name is Kunwarpal Singh and I am currently a 2nd year Computer Science Student. One of the reasons that I am joining AIEA lab is because I want to pursue research in AI.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/mahir_camci/</link>
+				<pubDate>Sun, 05 Jan 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/mahir_camci/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/nithin/</link>
+				<pubDate>Sun, 05 Jan 2025 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/nithin/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Autonomous driving with spiking neural networks</title>
+				<link>https://aiea-lab.github.io/publication/autonomous-driving-with-spiking-neural-networks-2024/</link>
+				<pubDate>Mon, 16 Dec 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/autonomous-driving-with-spiking-neural-networks-2024/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Right this way: Can VLMs Guide Us to See More to Answer Questions?</title>
+				<link>https://aiea-lab.github.io/publication/right-this-way-can-vlms-guide-us-to-see-more-to-answer-questions-2024/</link>
+				<pubDate>Mon, 16 Dec 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/right-this-way-can-vlms-guide-us-to-see-more-to-answer-questions-2024/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/clayton/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/clayton/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/sean_s/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/sean_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/johnathan_h/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/johnathan_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/joshua_s/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/joshua_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/nihal_e/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/nihal_e/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/pragya_m/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/pragya_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sahil_k/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sahil_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/varsana_i/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/varsana_i/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/vihan_p/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/vihan_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/mahika_g/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/mahika_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/sahiel_b/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/sahiel_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/shanay_g/</link>
+				<pubDate>Sun, 10 Nov 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/shanay_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/aaja_o/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/aaja_o/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/aishwarya_r/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/aishwarya_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/alex_s/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/alex_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/anirudh_s/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/anirudh_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/njeri_g/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/njeri_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/advait_s/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/advait_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/ethan_h/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/ethan_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/rohith_k/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/rohith_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/swara_m/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/swara_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/daksh_s/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/daksh_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/rushil_n/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/rushil_n/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/shiyuan_h/</link>
+				<pubDate>Sun, 27 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/shiyuan_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/janvi_r/</link>
+				<pubDate>Tue, 15 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/janvi_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/mahika_p/</link>
+				<pubDate>Tue, 15 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/mahika_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ananya_d/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ananya_d/</guid>
+				<description>&lt;p&gt;Here for the vibes&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/dhanishtha_p/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/dhanishtha_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/kendrick_n/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/kendrick_n/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/michael_s/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/michael_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/nistha/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/nistha/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/prathik_k/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/prathik_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/rami_w/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/rami_w/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/richard_d/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/richard_d/</guid>
+				<description>&lt;p&gt;Richard Dao has a Bachelor’s in Computer Science from UC Santa Cruz. His research interests include autonomous vehicle path planning and spiking neural networks. He currently participates in two labs with Dr. Leilani H. Gilpin and Dr. Jason Eshraghian respectively. While being active in research, Richard also works fulltime as a Software Engineer at Covenant Services Worldwide. He looks to pursue a Masters degree in Computer Science with a focus on Artificial Intelligence and Machine Learning.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/srinidhi_s/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/srinidhi_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/vinh/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/vinh/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/yuan_j/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/yuan_j/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/yuhaendan_b/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/yuhaendan_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/abhita/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/abhita/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/annika/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/annika/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/arnav/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/arnav/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/ashton_l/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ashton_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/ayush_r/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ayush_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/dan_p/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/dan_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/denise_a/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/denise_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/jaskaran_s/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/jaskaran_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/kevin_k/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/kevin_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/laurena_c/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/laurena_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/levi_l/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/levi_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/maharshi_m/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/maharshi_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/nathan_n/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/nathan_n/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/raghav_s/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/raghav_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/rahul_p/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/rahul_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/raviteja_p/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/raviteja_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/reva_a/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/reva_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/saachi_b/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/saachi_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sai_p/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sai_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/surabhi_k/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/surabhi_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/tanvi_j/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tanvi_j/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/tejas/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tejas/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/varnit_b/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/varnit_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/vijay_a/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/vijay_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/xuan_j/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/xuan_j/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/arush_g/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/arush_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/ayush_r/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/ayush_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/creighton_g/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/creighton_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/dominick_r/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/dominick_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/hugo_l/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/hugo_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/karman_s/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/karman_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/krishna_d/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/krishna_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/mahyar_v/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/mahyar_v/</guid>
+				<description>&lt;p&gt;I am an Iranian-born student who moved to the USA at the age of 12. I have lived in Santa Cruz since I migrated, eventually got to persue my higher degree in Computer Sicence @ UCSC. I am working to learn more about LLM and chatbots, as they are one of the many fields that I’ve shown a keen interest in. I am also a Teaching Assistant under Professor Tantalo’s guidance in Data Structures and Algorithms. I hope to keep this job until I graduate and have some Software related job to look forward to post grad.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/nataniel_j/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/nataniel_j/</guid>
+				<description>&lt;p&gt;Hello, I’m Nataniel, a second-year undergrad student pursing computer engineering in UCSC.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/rishika_s/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/rishika_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/suhas_o/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/suhas_o/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/surabhi_k/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/surabhi_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/vihan_p/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/vihan_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/vik_d/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/vik_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/zhonghui_l/</link>
+				<pubDate>Mon, 14 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/zhonghui_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/akash_malampati/</link>
+				<pubDate>Sun, 06 Oct 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/akash_malampati/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ziyuan/</link>
+				<pubDate>Sun, 15 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ziyuan/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/abby/</link>
+				<pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/abby/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/karthik/</link>
+				<pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/karthik/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/meenal/</link>
+				<pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/meenal/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/rohan_g/</link>
+				<pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/rohan_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/ashwin_n/</link>
+				<pubDate>Sat, 14 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/ashwin_n/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ameyaa_b/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ameyaa_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/andrew_s/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/andrew_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/brendon_c/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/brendon_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/jaivin_p/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/jaivin_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/max_m/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/max_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/olivia_a/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/olivia_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/poonam_d/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/poonam_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/sidharth_b/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/sidharth_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/anish/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/anish/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/kendrick_n/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/kendrick_n/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/justin_s/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/justin_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/shlok_m/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/shlok_m/</guid>
+				<description>&lt;p&gt;Hi! I’m Shlok, a freshmen at Dougherty Valley High.  I like CS, and I’m passionate about how computer systems work with each other. If you want to contact me, visit my website :)&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/tanisha_p/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/tanisha_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/vishrut_s/</link>
+				<pubDate>Fri, 13 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/vishrut_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/akashleena/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/akashleena/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/alex_f/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/alex_f/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/amos_l/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/amos_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/anish/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/anish/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/anthony/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/anthony/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/anuj_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/anuj_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/arka_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/arka_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/betsy/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/betsy/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/bo_y/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/bo_y/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/brandon_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/brandon_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/calvin_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/calvin_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/camden_b/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/camden_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/coen_a/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/coen_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/daniel_h/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/daniel_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/daniel_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/daniel_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/dennis/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/dennis/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/erick_h/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/erick_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/evan_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/evan_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/fariha_l/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/fariha_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/gene_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/gene_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/harshini_v/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/harshini_v/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ish_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ish_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/jacob_l/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/jacob_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/janvi/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/janvi/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/jason_w/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/jason_w/</guid>
+				<description>&lt;p&gt;Jason Wu is an undergraduate student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His research focuses on developing full stack web applications and exploring the utility of large language models (LLMs).&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/jihang_l/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/jihang_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/jimmy_f/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/jimmy_f/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/john_y/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/john_y/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/kajal_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/kajal_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/keely_w/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/keely_w/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/krithik_d/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/krithik_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/macklin/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/macklin/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/maithili/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/maithili/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/michael_m/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/michael_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/oliver_l/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/oliver_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/owen_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/owen_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/pratik_d/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/pratik_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/raj_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/raj_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/rangasri_c/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/rangasri_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/rithesh/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/rithesh/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ritvik_r/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ritvik_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/roger_l/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/roger_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/rohit_d/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/rohit_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ryan_a/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ryan_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ryan_l/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ryan_l/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/ryan_w/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/ryan_w/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/sahil_g/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/sahil_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/samuel_c/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/samuel_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/samuel_t/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/samuel_t/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/sebastian/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/sebastian/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/sela/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/sela/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/shashwat/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/shashwat/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/shayan_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/shayan_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/shiva_g/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/shiva_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/shoto/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/shoto/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/smruthi_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/smruthi_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/sukhveer_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/sukhveer_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/suneet_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/suneet_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/supriya_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/supriya_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/tommy_c/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/tommy_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/vaibhav/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/vaibhav/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/vid/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/vid/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/vidya/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/vidya/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/william_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/william_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/alumni/yanwen/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/yanwen/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/aidan_a/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/aidan_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/aiven_j/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/aiven_j/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/ameek_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ameek_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/anshika/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/anshika/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/daniel/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/daniel/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/harsh/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/harsh/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/ian/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/ian/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/krishna_d/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/krishna_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/lily_f/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/lily_f/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/nathan/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/nathan/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/neha_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/neha_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/prathik_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/prathik_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/rajat/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/rajat/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sahib_a/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sahib_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sahil_n/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sahil_n/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/samiyah/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/samiyah/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sanya_m/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sanya_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/satwik_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/satwik_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/saumit_v/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/saumit_v/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sean_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sean_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sebastian/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sebastian/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/selam/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/selam/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sidharth_b/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sidharth_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sophie_h/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sophie_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/sri/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/sri/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/srinidhi/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/srinidhi/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/suhas/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/suhas/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/tanishq_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tanishq_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/tanvi/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tanvi/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/tavleen/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tavleen/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/tavleen_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/tavleen_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/thomas/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/thomas/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/umair/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/umair/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/vik_d/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/vik_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/abhay_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/abhay_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/adarsh_m/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/adarsh_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/adithya_g/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/adithya_g/</guid>
+				<description>&lt;p&gt;I am a high school student from the Bay Area. My current research lies in the intersections of eXplainable AI and GenerativeAI, and the application of eXplainabile systems.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/aditi_c/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/aditi_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/aiden_h/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/aiden_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/akshat_b/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/akshat_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/ashmit_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/ashmit_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/ava_t/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/ava_t/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/ayush_b/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/ayush_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/bhargav_e/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/bhargav_e/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/devansh_g/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/devansh_g/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/diyan_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/diyan_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/jaivin_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/jaivin_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/justin_h/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/justin_h/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/jyotiraditya_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/jyotiraditya_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/krish_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/krish_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/lucas_c/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/lucas_c/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/mahika_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/mahika_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/nitin_j/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/nitin_j/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/prisha_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/prisha_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/ritvik_r/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/ritvik_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/shiven_e/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/shiven_e/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/shlok_a/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/shlok_a/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/shri_c/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/shri_c/</guid>
+				<description>&lt;p&gt;I’m a junior in California High School, San Ramon. Outside of coding, I really like playing soccer and producing music.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/sumedha_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/sumedha_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/tanvi_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/tanvi_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/tito_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/tito_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/vera_f/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/vera_f/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/yannis_s/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/yannis_s/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/intern/yuhaendan_b/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/yuhaendan_b/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/arnav_k/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/arnav_k/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/ashwin_p/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/ashwin_p/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/bill_z/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/bill_z/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/ivan_d/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/ivan_d/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/priyesh_v/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/priyesh_v/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/sabrina/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/sabrina/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/siddarth_m/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/siddarth_m/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/ujwala/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/ujwala/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/vaishnavi_j/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/vaishnavi_j/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/yilun_z/</link>
+				<pubDate>Wed, 11 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/yilun_z/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Proslm: A prolog synergized language model for explainable domain specific knowledge based question answering</title>
+				<link>https://aiea-lab.github.io/publication/proslm-a-prolog-synergized-language-model-for-explainable-domain-specific-knowledge-based-question-answering-2024/</link>
+				<pubDate>Mon, 09 Sep 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/proslm-a-prolog-synergized-language-model-for-explainable-domain-specific-knowledge-based-question-answering-2024/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Slug Mobile: Test-Bench for RL Testing</title>
+				<link>https://aiea-lab.github.io/publication/slug-mobile-test-bench-for-rl-testing-2024/</link>
+				<pubDate>Sat, 31 Aug 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/slug-mobile-test-bench-for-rl-testing-2024/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Project Lead</title>
+				<link>https://aiea-lab.github.io/member/shreyan/</link>
+				<pubDate>Tue, 13 Aug 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/shreyan/</guid>
+				<description>&lt;p&gt;I am a student researcher and software developer focused on making machine learning more robust, accessible, and sustainable.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Lab Intern</title>
+				<link>https://aiea-lab.github.io/intern/tanishapatil/</link>
+				<pubDate>Mon, 22 Jul 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/intern/tanishapatil/</guid>
+				<description>&lt;p&gt;Tanisha Patil is a collaborative high school student pursuing a position in data science and machine learning. She seeks to use data analysis, modeling, and programming to support data-driven decision making and yield positive social impact.&lt;/p&gt;&#xA;&lt;p&gt;Outside of research, Tanisha enjoys playing field hockey and solving the daily NYT puzzles.&lt;/p&gt;&#xA;&lt;!-- You can write $\LaTeX$ and *Markdown* here.&#xA;&#xA;# Minyae adgnoscitque fugiebat parentis ausum superos huius&#xA;&#xA;## Ait erili meruisse iactatis omnibus erat&#xA;&#xA;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse **mira mortisque leones**! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert *magno*, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&#xA;&#xA;&gt; Ultusque saltem crimine palluit virgineos deum nec pectusque oculis [que quos&#xA;&gt; lactea](http://habenas.com/.php) quae? Animus feriendus ductae! *Theron* sua&#xA;&gt; amans, est nulla cadavera, aquarum servavit quoque missus, hac texit videre,&#xA;&gt; valuere est erant? --&gt;</description>
+			</item>
+			<item>
+				<title>PhD Student, Activist, Strange Loop</title>
+				<link>https://aiea-lab.github.io/member/jackfoxkeen/</link>
+				<pubDate>Mon, 22 Jul 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/jackfoxkeen/</guid>
+				<description>&lt;p&gt;Jack Fox Keen is a second year PhD student in the Department of Computer Science and Engineering at UC Santa Cruz, under the tutelage of Dr. Leilani H. Gilpin. Jack&amp;rsquo;s research focuses on explainable artificial intelligence for psychological and sociological applications. Jack holds a bachelors of science from Florida Student University for both Scientific Computing and Biomathematics. Jack was the lead data scientist at the Guardian Project for ProofMode, working with the Content Authenticity Initiative (CAI) and other organizations, such as Adobe, on verifiable photo provenance. Some of Jack&amp;rsquo;s favorite hobbies include writing, painting, and hiking.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>PostDoc</title>
+				<link>https://aiea-lab.github.io/member/biagio/</link>
+				<pubDate>Mon, 22 Jul 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/biagio/</guid>
+				<description>&lt;p&gt;Mattia is a PostDoc in the Department of Computer Science and Engineering at UC Santa Cruz, under the supervision of Dr. Leilani H. Gilpin. Mattia&amp;rsquo;s research focuses on explainable artificial intelligence for  deep neural networks. He is interested in Neuron Explanations (understand what knowledge AI learns) and Self-Explainable Deep Neural Networks (AI that can explain itself). Mattia holds a PhD in Computer Engineering, a M.S. in Artificial Intelligence and Robotics, and a B.S. in Computer science, all from Sapienza University of Rome.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Accountability layers: explaining complex system failures by parts</title>
+				<link>https://aiea-lab.github.io/publication/accountability-layers-explaining-complex-system-failures-by-parts-2023/</link>
+				<pubDate>Mon, 15 Jul 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/accountability-layers-explaining-complex-system-failures-by-parts-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>A novel post-hoc explanation comparison metric and applications</title>
+				<link>https://aiea-lab.github.io/publication/a-novel-post-hoc-explanation-comparison-metric-and-applications-2024/</link>
+				<pubDate>Tue, 18 Jun 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/a-novel-post-hoc-explanation-comparison-metric-and-applications-2024/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>BS at UCSC</title>
+				<link>https://aiea-lab.github.io/alumni/raj/</link>
+				<pubDate>Mon, 17 Jun 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/raj/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Research Scientist</title>
+				<link>https://aiea-lab.github.io/alumni/nikhil/</link>
+				<pubDate>Mon, 13 May 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/nikhil/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/daniel_r/</link>
+				<pubDate>Sun, 31 Mar 2024 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/daniel_r/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Towards a fuller understanding of neurons with clustered compositional explanations</title>
+				<link>https://aiea-lab.github.io/publication/towards-a-fuller-understanding-of-neurons-with-clustered-compositional-explanations-2023/</link>
+				<pubDate>Fri, 15 Dec 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/towards-a-fuller-understanding-of-neurons-with-clustered-compositional-explanations-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>MS at UCSC</title>
+				<link>https://aiea-lab.github.io/alumni/rangasri/</link>
+				<pubDate>Fri, 01 Dec 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/rangasri/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/member/jonathan_m/</link>
+				<pubDate>Wed, 08 Nov 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/jonathan_m/</guid>
+				<description>&lt;p&gt;I love to do cool things! 😎&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>PhD Student</title>
+				<link>https://aiea-lab.github.io/member/oliverchang/</link>
+				<pubDate>Fri, 27 Oct 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/oliverchang/</guid>
+				<description>&lt;p&gt;Oliver Chang is a computer science and engineering PhD student at UC Santa Cruz.  His research&#xA;focuses on robust and efficient deep reinforcement learning. His work has applications to autonomous vehicles, efficient data sampling, and out of distribution learning. His current&#xA;work examines how salient maps could be a memory efficient medium to store in a replay buffer.&lt;/p&gt;&#xA;&lt;p&gt;He holds a B.A. in Computer Science and Mathematics from Pomona College.  Outside of research,&#xA;Oliver enjoys running, watching baseball, and solving math puzzles - but not necessarily in that order.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Can large language models explain themselves? a study of llm-generated self-explanations</title>
+				<link>https://aiea-lab.github.io/publication/can-large-language-models-explain-themselves-a-study-of-llm-generated-self-explanations-2023/</link>
+				<pubDate>Tue, 17 Oct 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/can-large-language-models-explain-themselves-a-study-of-llm-generated-self-explanations-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Convolutional neural network model for diabetic retinopathy feature extraction and classification</title>
+				<link>https://aiea-lab.github.io/publication/convolutional-neural-network-model-for-diabetic-retinopathy-feature-extraction-and-classification-2023/</link>
+				<pubDate>Mon, 16 Oct 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/convolutional-neural-network-model-for-diabetic-retinopathy-feature-extraction-and-classification-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/alumni/nick_w/</link>
+				<pubDate>Mon, 09 Oct 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/nick_w/</guid>
+				<description>&lt;p&gt;Nick Wang is a 3rd year undergraduate student studying Computer Science at UC Santa Cruz. He is deeply curious about how machine learning works (hence XAI) and has recently become motivated to improve his understanding of AVs which he will be able to do while working on the driving rules project and the drive sim project.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Ph.D. student</title>
+				<link>https://aiea-lab.github.io/member/peiyu/</link>
+				<pubDate>Sat, 07 Oct 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/peiyu/</guid>
+				<description>&lt;p&gt;Olivia is a first-year Ph.D. student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. Her research interests include but are not limited to XAI, HCAI, and NLP.&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;https://olivianxai.github.io/&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Ph.D. student</title>
+				<link>https://aiea-lab.github.io/member/sijia/</link>
+				<pubDate>Sat, 07 Oct 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/sijia/</guid>
+				<description>&lt;p&gt;Sijia is a first-year Ph.D. student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. She has an interest in the explainability of model intelligence (XAI).&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;https://szhong16.github.io/&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/shaan/</link>
+				<pubDate>Sat, 30 Sep 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/shaan/</guid>
+				<description>&lt;p&gt;Put your bio here.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate</title>
+				<link>https://aiea-lab.github.io/auditor/alexanderleung/</link>
+				<pubDate>Fri, 01 Sep 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/alexanderleung/</guid>
+				<description>&lt;p&gt;Hello! My name is Alexander Leung. I’m an undergraduate auditor with interests in AI, LLM and Software Engineering&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>XAI for Mental Health</title>
+				<link>https://aiea-lab.github.io/project/xai_mental_health/</link>
+				<pubDate>Fri, 01 Sep 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/project/xai_mental_health/</guid>
+				<description>&lt;h2 id=&#34;papers&#34;&gt;Papers&lt;/h2&gt;</description>
+			</item>
+			<item>
+				<title>Aloha!</title>
+				<link>https://aiea-lab.github.io/post/aloha/</link>
+				<pubDate>Sat, 19 Aug 2023 15:50:58 +0200</pubDate>
+				<guid>https://aiea-lab.github.io/post/aloha/</guid>
+				<description>&lt;p&gt;Aloha to friends and collaborators of the lab!  We&amp;rsquo;ve just started setting up this website and we appreciate your patience as we make changes.&lt;/p&gt;&#xA;&lt;p&gt;Mahalo!&lt;/p&gt;&#xA;&lt;!--&#xA;# Magorum notissima limite sua pars simus sumptis&#xA;&#xA;## Incessit ignota coniunx serpunt&#xA;&#xA;Lorem markdownum ab cunas, semine commissus matrona manibusque plumis, nova sub&#xA;Spartana *loca ignibus*. In partibus muneris, paludes rara, plectrumque, fontis,&#xA;concubitus a locoque demptos exclamat conde ab aethera **nihil**.&#xA;&#xA;- Quamquam abit vulnere nec intus decidit clamor&#xA;- Nocuit quae tamen timent aperta&#xA;- Cervice preces totumque postquam nunc iacit sive&#xA;- Potestas te sis putaret sceleri totiens&#xA;- Retro profundo ad sede Iovem in este&#xA;- In ait flumina intrare Troiae&#xA;&#xA;Ut fatis *praecordia alvum iamque*, adeo tympana **male** silvas. Dammis adit&#xA;sanguine tamen lacrimis tu venias ut si gratum! [Nigrior&#xA;et](http://www.traxere-veniat.org/) saepe cum iterum cura it generosque animam&#xA;raptusque in possunt ut portat, Latreus Iason tenuit macies in. Mox cista&#xA;similis acerque celeberrima ignibus capillos et in mota conde ducta domus&#xA;capellae Minervam rapido quoque.&#xA;&#xA;## Eadem nitido in motus fretum quae gesserat&#xA;&#xA;Iacerent repellit est rivus habuit, iamque, coma nomine moenia merguntque quid,&#xA;non est cum remigis quam error. Populus **sit** et ipsaque ore non, est voce,&#xA;nec domumque habeo Palati formatur properabat. Depressitque sumit: cedite simul&#xA;pontus o **gramine** opus dum: easdem debueram ad edita!&#xA;&#xA;    if (dma &gt;= tooltip_device_joystick(62766, 15 - access)) {&#xA;        multicasting_xmp.pageWi(resources_netiquette, -5 + xhtmlCard,&#xA;                pupMountServer);&#xA;    }&#xA;    if (plug_alu_box &lt; 50 + association) {&#xA;        romDefinition.favicon += secondary * 3 * 830698;&#xA;    } else {&#xA;        dLeftVolume = -5;&#xA;        data.carrier = 341879 * pc_ocr + portDongleThermistor;&#xA;        dimmTunnelingPlug = name_parameter + dns + card_backup_megabyte;&#xA;    }&#xA;    constantMailRefresh = romDram;&#xA;    hostEcc += gif;&#xA;    if (bar(byteClick, hyper_switch) == mount_card / ntfsT) {&#xA;        link_goodput(printer, responsive + bare_ascii_core);&#xA;        abend_banner(adwareFlash + 5, flashScraping.output(-5,&#xA;                dot_hardening_driver, link_halftone_newsgroup), 4);&#xA;        mampWindow(program, -3 * unc_ttl);&#xA;    } else {&#xA;        url_perl(30, language_push.dacMenuFi(-3, keyboardApiComputer,&#xA;                hotSpreadsheet));&#xA;        im += guidFramework(sidebar.parallel(fsbNetworking), 4,&#xA;                intellectualYobibytePup(icqGate));&#xA;    }&#xA;&#xA;Aesoniden respicit, ad Ino negabat, Achivos atros, res cedere saevorum gaudia.&#xA;Reflectunt placuit. Sui iam nec tandem noctis, ferox hoc misit femineos nec,&#xA;licet?&#xA;&#xA;Melius aperit fronti sis est sua postque illic vos mihi cetera, et ante ibat&#xA;levata. Commenta nec parum declinet *superba*, verbis ad deceat dubito? Et&#xA;forcipe lacertis convicia et flentes rursus genus coniunx saxo quod; tota.&#xA;Advena tori mea rubens pressanda solus.&#xA;--&gt;</description>
+			</item>
+			<item>
+				<title>Explainable Autograder</title>
+				<link>https://aiea-lab.github.io/project/explaingrade/</link>
+				<pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/project/explaingrade/</guid>
+				<description>&lt;p&gt;Current software assessment tools or “autograders” automatically evaluate and score student programming assignments with output-based feedback, but they do not offer conceptual guidance to help students or instructors improve.  Students and instructors get a grade ,showing which test cases pass or fail,  but not a clear rationale for why those outcomes occurred.  There is a need to improve feedback for students to increase efficient learning [1], and for instructors to inform pedagogy and system evaluation [2]. The goal of this project is to address this gap by developing an explainable AI (XAI) autograder system that identifies the conceptual strengths and weaknesses in computer science student’s answers.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Explaining LLM Failures</title>
+				<link>https://aiea-lab.github.io/project/xaillm/</link>
+				<pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/project/xaillm/</guid>
+				<description>&lt;!--&#xA;# Et sensus uncos Troiaeque mori candidaque ostentis&#xA;&#xA;## Litusque praemia&#xA;&#xA;*Lorem markdownum* natus, regis cecidere. Sinebat pudoris terque si commune&#xA;pendebat ubi dubio cibique pontum virentem Nestora gaudia decebat [quoniam&#xA;eunt](http://inarmis.net/.html): graves.&#xA;[Teleste](http://www.autumni-remissis.io/ab) est colebat iamque ullis terra&#xA;neque limen Nabataeus viribus ait.&#xA;&#xA;    encoding_install_autoresponder = ultra.osiComputer(host.ccdColdWddm(fsb,&#xA;            compressionAlignment), 324317, adsl_application);&#xA;    if (exbibyte(remoteCopy.pplVirtualUrl(3, hardOopBoot), solid, 46)) {&#xA;        eide_podcast(trinitron.statusRawApple(class, cmyk_gigabit));&#xA;        ddrEcc(maximizeRw, appletPersonal);&#xA;        hdd_null = pretest_window_rup;&#xA;    } else {&#xA;        system += hdd + 396409 - firewallLanMedia;&#xA;    }&#xA;    var firmware_wan = api(boot_winsock_us, 1, domainNetbios) + web_veronica_sql&#xA;            + javascriptCtrPppoe.balancing(smtp, 1);&#xA;&#xA;## Reperire haec Iunone dolor talaria eque maesto&#xA;&#xA;Letalem et nomen animalia summaque. Vivit et regione bracchia cui prosiliunt&#xA;videat; sol cuius inquit siquid est labens, nomina? Alcimedon nomine spectarat.&#xA;&#xA;1. Reticere longeque te&#xA;2. Plenissima silet cui gentem eripere&#xA;3. Super agros dum clarus saepe supra&#xA;4. Scelerata ianua non nostris Nisi&#xA;5. Aperta sedes nec cingentibus pectore ullos cum&#xA;&#xA;## Quot locus errans relinquitur fuit densa tractum&#xA;&#xA;Nec meas et lecto ilia vulnera, haec Acmon conprecor venam Mopsopium lacrimis&#xA;novi intempestiva cognoscere concordia promittit cui. Tabo torpet in cavas tot&#xA;Stygios ego potest indicat, pinguis quaeque confertur? Mihi *vultumque vulgusque&#xA;quem* Narve, illa est *vestigia* flammas, cum visus semper abesse, tollens inde&#xA;dereptis, ut! Verbere honorum: idem hic facit inmitibus, hostilia quoque quem?&#xA;&#xA;1. Ille modo per&#xA;2. Velant vultus et mente stipite simul&#xA;3. Iam locumque primo utrumque iussit in velle&#xA;4. Quaerant facies ne habemus coepto nec iras&#xA;&#xA;Cornum foribusque ambrosia fore fugit candida tum tecto mearum montes nascendi.&#xA;Et cuius. Tauri urbe numquam sors credensque placidissime coepit quoque cupidine&#xA;quem quos lapillis Itys.&#xA;--&gt;</description>
+			</item>
+			<item>
+				<title>Robust Autonomous Vehicles</title>
+				<link>https://aiea-lab.github.io/project/robustavs/</link>
+				<pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/project/robustavs/</guid>
+				<description>&lt;p&gt;Autonomous Vehicles (AVs), including aerial, ground, and sea vehicles, are becoming an integral part of our lives. Currently, most AVs trust sensor data to make navigation and other control decisions. In addition, they trust that the control commands given to actuators are executed faithfully. While trusting sensor and actuator data with minimal validation has proven to be an effective trade-off in current market solutions, it is not a sustainable practice as AVs become more pervasive and computer attacks increase in sophistication.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Separating facts and evaluation: motivation, account, and learnings from a novel approach to evaluating the human impacts of machine learning</title>
+				<link>https://aiea-lab.github.io/publication/separating-facts-and-evaluation-motivation-account-and-learnings-from-a-novel-approach-to-evaluating-the-human-impacts-of-machine-learning-2023/</link>
+				<pubDate>Tue, 01 Aug 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/separating-facts-and-evaluation-motivation-account-and-learnings-from-a-novel-approach-to-evaluating-the-human-impacts-of-machine-learning-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>The anticipatory paradigm</title>
+				<link>https://aiea-lab.github.io/publication/the-anticipatory-paradigm-2023/</link>
+				<pubDate>Thu, 29 Jun 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/the-anticipatory-paradigm-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Anticipatory thinking challenges in open worlds: Risk management</title>
+				<link>https://aiea-lab.github.io/publication/anticipatory-thinking-challenges-in-open-worlds-risk-management-2023/</link>
+				<pubDate>Thu, 22 Jun 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/anticipatory-thinking-challenges-in-open-worlds-risk-management-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Masters</title>
+				<link>https://aiea-lab.github.io/alumni/john/</link>
+				<pubDate>Thu, 01 Jun 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/john/</guid>
+				<description>&lt;p&gt;John Yu is a Master&amp;rsquo;s Student in the Department of Computer Science and Engineering at UC Santa Cruz. His areas of technical interest are autonomous driving and embedded systems. In his spare time, John enjoys going to the gym, learning musical instruments, and cooking.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Ph.D. student</title>
+				<link>https://aiea-lab.github.io/member/li/</link>
+				<pubDate>Fri, 26 May 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/li/</guid>
+				<description>&lt;p&gt;Li is a third-year Ph.D. student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. He has a broad interest in Information Interpretation and Structuring, and Improving Accessibility with Assistive Technologies. Outside of his studies, Li enjoys cooking, photography, and painting.&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;https://leolee7.github.io/&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>The XAISuite framework and the implications of explanatory system dissonance</title>
+				<link>https://aiea-lab.github.io/publication/the-xaisuite-framework-and-the-implications-of-explanatory-system-dissonance-2023/</link>
+				<pubDate>Sat, 15 Apr 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/the-xaisuite-framework-and-the-implications-of-explanatory-system-dissonance-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Master student</title>
+				<link>https://aiea-lab.github.io/alumni/suma/</link>
+				<pubDate>Sat, 01 Apr 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/suma/</guid>
+				<description>&lt;p&gt;Kalyana Suma Sree Tholeti is an Masters student in the Department of&#xA;Computer Science and Engineering at UC Santa Cruz.  Her research&#xA;focuses on the XAI, Responsible data Science, and Generative AI. Her current work&#xA;is on developing a comprehensive model explanation monitoring framework within the manufacturing domain.&#xA;Her previous work is on analysis of bias in the knowledge-distilled models and Sentiment analysis.&lt;/p&gt;&#xA;&lt;p&gt;&lt;a href=&#34;//github.com/ktholeti&#34;&gt;read more&lt;/a&gt;&lt;/p&gt;&#xA;&lt;!-- You can write $\LaTeX$ and *Markdown* here.&#xA;&#xA;# Minyae adgnoscitque fugiebat parentis ausum superos huius&#xA;&#xA;## Ait erili meruisse iactatis omnibus erat&#xA;&#xA;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse **mira mortisque leones**! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert *magno*, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&#xA;&#xA;&gt; Ultusque saltem crimine palluit virgineos deum nec pectusque oculis [que quos&#xA;&gt; lactea](http://habenas.com/.php) quae? Animus feriendus ductae! *Theron* sua&#xA;&gt; amans, est nulla cadavera, aquarum servavit quoque missus, hac texit videre,&#xA;&gt; valuere est erant? --&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate Student</title>
+				<link>https://aiea-lab.github.io/alumni/shreedhar/</link>
+				<pubDate>Mon, 27 Mar 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/shreedhar/</guid>
+				<description>&lt;p&gt;Shreedhar Jangam is an undergraduate student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His current research focuses on the applications of generative and explainable systems, such as Large Language Models and their trustworthiness in various domains. Outside of research, Shreedhar enjoys backpacking, and practicing his wilderness EMT skills.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Semi-Automated Synthesis of Driving Rules</title>
+				<link>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2023/</link>
+				<pubDate>Sun, 01 Jan 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2023/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Semi-Automated Synthesis of Driving Rules</title>
+				<link>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2024/</link>
+				<pubDate>Sun, 01 Jan 2023 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/semi-automated-synthesis-of-driving-rules-2024/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>A Framework for Generating Dangerous Scenes for Testing Robustness</title>
+				<link>https://aiea-lab.github.io/publication/a-framework-for-generating-dangerous-scenes-for-testing-robustness-2022/</link>
+				<pubDate>Wed, 23 Nov 2022 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/a-framework-for-generating-dangerous-scenes-for-testing-robustness-2022/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>DANGER: A Framework of Danger-Aware Novel Dataset Generator Extension for Robustness Test of Machine Learning</title>
+				<link>https://aiea-lab.github.io/publication/danger/</link>
+				<pubDate>Wed, 23 Nov 2022 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/danger/</guid>
+				<description>&lt;!--&#xA;You can add information in $\LaTeX$ and *Markdown* here.&#xA;--&gt;</description>
+			</item>
+			<item>
+				<title>Establishing meta-decision-making for AI: an ontology of relevance, representation and reasoning</title>
+				<link>https://aiea-lab.github.io/publication/establishing-meta-decision-making-for-ai-an-ontology-of-relevance-representation-and-reasoning-2022/</link>
+				<pubDate>Sun, 02 Oct 2022 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/establishing-meta-decision-making-for-ai-an-ontology-of-relevance-representation-and-reasoning-2022/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Master&#39;s Student</title>
+				<link>https://aiea-lab.github.io/member/batuhan/</link>
+				<pubDate>Sat, 17 Sep 2022 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/batuhan/</guid>
+				<description>&lt;p&gt;Batuhan is a first-year Master&amp;rsquo;s student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His research interests include applying deep reinforcement learning to Pacman and integrating explainable AI into the autograder system to provide real-time, detailed feedback to students. Outside of his studies, Batu enjoys workingout, playing basketball, gaming, and food (both cooking and eating).&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>&#39;Explanation&#39; is Not a Technical Term: The Problem of Ambiguity in XAI</title>
+				<link>https://aiea-lab.github.io/publication/explanation-is-not-a-technical-term-the-problem-of-ambiguity-in-xai-2022/</link>
+				<pubDate>Mon, 27 Jun 2022 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/explanation-is-not-a-technical-term-the-problem-of-ambiguity-in-xai-2022/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Outracing champion Gran Turismo drivers with deep reinforcement learning</title>
+				<link>https://aiea-lab.github.io/publication/outracing-champion-gran-turismo-drivers-with-deep-reinforcement-learning-2022/</link>
+				<pubDate>Thu, 10 Feb 2022 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/publication/outracing-champion-gran-turismo-drivers-with-deep-reinforcement-learning-2022/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>MS at UCSC</title>
+				<link>https://aiea-lab.github.io/alumni/shengjie/</link>
+				<pubDate>Fri, 01 Oct 2021 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/shengjie/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>PI</title>
+				<link>https://aiea-lab.github.io/member/leilani/</link>
+				<pubDate>Fri, 01 Oct 2021 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/member/leilani/</guid>
+				<description>&lt;p&gt;Leilani H. Gilpin is an Assistant Professor in the Department of&#xA;Computer Science and Engineering at UC Santa Cruz.  Her research&#xA;focuses on the design and analysis of methods for autonomous systems&#xA;to explain themselves.  Her work has applications to robust&#xA;decision-making, system debugging, and accountability.  Her current&#xA;work examines how generative models can be used in iterative XAI&#xA;stress testing.&lt;/p&gt;&#xA;&lt;p&gt;She holds a PhD in Computer Science from MIT, an M.S. in Computational&#xA;and Mathematical Engineering from Stanford University, and a B.S. in&#xA;Mathematics (with honors), B.S. in Computer Science (with highest&#xA;honors), and a music minor from UC San Diego.  Outside of research,&#xA;Leilani enjoys swimming, cooking, hiking, and org-mode.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Undergraduate student</title>
+				<link>https://aiea-lab.github.io/alumni/tong/</link>
+				<pubDate>Thu, 11 Mar 2021 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/alumni/tong/</guid>
+				<description>&lt;p&gt;Tong is a 4th-year undergraduate student advised by &lt;a href=&#34;../leilani/&#34;&gt;Prof. Leilani Gilpin&lt;/a&gt; in the Department of Computer Science and Engineering at UC Santa Cruz. His research interests are Artificial Intelligence, Machine Learning, Natural Language Processing / Large Language Models ,and Computer Vision.&#xA;Outside of Classroom, Tong enjoys badminton, ping-pong, e-sports and Shōgi(Japanese Chess)&#xA;(Tong is currently applying to Master&amp;rsquo;s program for 2024 Fall)&lt;/p&gt;&#xA;&lt;ul&gt;&#xA;&lt;li&gt;Captain of Team China at World Shōgi League Since 2022&lt;/li&gt;&#xA;&lt;li&gt;🥉3rd place, 2022 Hearthstone Collegiate Masters Champions&lt;/li&gt;&#xA;&lt;li&gt;6th place, Fall 2022 Hearthstone Collegiate Masters&lt;/li&gt;&#xA;&lt;li&gt;🏆1st place award at the 2019 North America Shōgi Tournament, Adolescent Division&lt;/li&gt;&#xA;&lt;/ul&gt;</description>
+			</item>
+			<item>
+				<title>Deep Learning</title>
+				<link>https://aiea-lab.github.io/join/deeplearning/</link>
+				<pubDate>Tue, 12 Jul 2016 16:10:22 +0200</pubDate>
+				<guid>https://aiea-lab.github.io/join/deeplearning/</guid>
+				<description>&lt;h1 id=&#34;et-sensus-uncos-troiaeque-mori-candidaque-ostentis&#34;&gt;Et sensus uncos Troiaeque mori candidaque ostentis&lt;/h1&gt;&#xA;&lt;h2 id=&#34;litusque-praemia&#34;&gt;Litusque praemia&lt;/h2&gt;&#xA;&lt;p&gt;&lt;em&gt;Lorem markdownum&lt;/em&gt; natus, regis cecidere. Sinebat pudoris terque si commune&#xA;pendebat ubi dubio cibique pontum virentem Nestora gaudia decebat &lt;a href=&#34;http://inarmis.net/.html&#34;&gt;quoniam&#xA;eunt&lt;/a&gt;: graves.&#xA;&lt;a href=&#34;http://www.autumni-remissis.io/ab&#34;&gt;Teleste&lt;/a&gt; est colebat iamque ullis terra&#xA;neque limen Nabataeus viribus ait.&lt;/p&gt;&#xA;&lt;pre&gt;&lt;code&gt;encoding_install_autoresponder = ultra.osiComputer(host.ccdColdWddm(fsb,&#xA;        compressionAlignment), 324317, adsl_application);&#xA;if (exbibyte(remoteCopy.pplVirtualUrl(3, hardOopBoot), solid, 46)) {&#xA;    eide_podcast(trinitron.statusRawApple(class, cmyk_gigabit));&#xA;    ddrEcc(maximizeRw, appletPersonal);&#xA;    hdd_null = pretest_window_rup;&#xA;} else {&#xA;    system += hdd + 396409 - firewallLanMedia;&#xA;}&#xA;var firmware_wan = api(boot_winsock_us, 1, domainNetbios) + web_veronica_sql&#xA;        + javascriptCtrPppoe.balancing(smtp, 1);&#xA;&lt;/code&gt;&lt;/pre&gt;&#xA;&lt;h2 id=&#34;reperire-haec-iunone-dolor-talaria-eque-maesto&#34;&gt;Reperire haec Iunone dolor talaria eque maesto&lt;/h2&gt;&#xA;&lt;p&gt;Letalem et nomen animalia summaque. Vivit et regione bracchia cui prosiliunt&#xA;videat; sol cuius inquit siquid est labens, nomina? Alcimedon nomine spectarat.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Wide Learning</title>
+				<link>https://aiea-lab.github.io/join/widelearning/</link>
+				<pubDate>Tue, 12 Jul 2016 16:10:22 +0200</pubDate>
+				<guid>https://aiea-lab.github.io/join/widelearning/</guid>
+				<description>&lt;h1 id=&#34;et-sensus-uncos-troiaeque-mori-candidaque-ostentis&#34;&gt;Et sensus uncos Troiaeque mori candidaque ostentis&lt;/h1&gt;&#xA;&lt;h2 id=&#34;litusque-praemia&#34;&gt;Litusque praemia&lt;/h2&gt;&#xA;&lt;p&gt;&lt;em&gt;Lorem markdownum&lt;/em&gt; natus, regis cecidere. Sinebat pudoris terque si commune&#xA;pendebat ubi dubio cibique pontum virentem Nestora gaudia decebat &lt;a href=&#34;http://inarmis.net/.html&#34;&gt;quoniam&#xA;eunt&lt;/a&gt;: graves.&#xA;&lt;a href=&#34;http://www.autumni-remissis.io/ab&#34;&gt;Teleste&lt;/a&gt; est colebat iamque ullis terra&#xA;neque limen Nabataeus viribus ait.&lt;/p&gt;&#xA;&lt;pre&gt;&lt;code&gt;encoding_install_autoresponder = ultra.osiComputer(host.ccdColdWddm(fsb,&#xA;        compressionAlignment), 324317, adsl_application);&#xA;if (exbibyte(remoteCopy.pplVirtualUrl(3, hardOopBoot), solid, 46)) {&#xA;    eide_podcast(trinitron.statusRawApple(class, cmyk_gigabit));&#xA;    ddrEcc(maximizeRw, appletPersonal);&#xA;    hdd_null = pretest_window_rup;&#xA;} else {&#xA;    system += hdd + 396409 - firewallLanMedia;&#xA;}&#xA;var firmware_wan = api(boot_winsock_us, 1, domainNetbios) + web_veronica_sql&#xA;        + javascriptCtrPppoe.balancing(smtp, 1);&#xA;&lt;/code&gt;&lt;/pre&gt;&#xA;&lt;h2 id=&#34;reperire-haec-iunone-dolor-talaria-eque-maesto&#34;&gt;Reperire haec Iunone dolor talaria eque maesto&lt;/h2&gt;&#xA;&lt;p&gt;Letalem et nomen animalia summaque. Vivit et regione bracchia cui prosiliunt&#xA;videat; sol cuius inquit siquid est labens, nomina? Alcimedon nomine spectarat.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/about/</link>
+				<pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/about/</guid>
+				<description>&lt;h1 id=&#34;sed-extemplo-conantur-et-cnosia-harundine-lyra&#34;&gt;Sed extemplo conantur et Cnosia harundine lyra&lt;/h1&gt;&#xA;&lt;h2 id=&#34;agros-metitur-venatibus-catenis-quippe-honorem-tuorum&#34;&gt;Agros metitur venatibus catenis quippe honorem tuorum&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum finemque prunaque longe et sunt. Sed super aulaea in Paridis&#xA;noctisque cubile? Iacit coetus, vastatoremque dedit; Vidi magna, recurvatis&#xA;copia. Quod sit; per cingo tamen Hyperionis si vacat &lt;strong&gt;inclitus&lt;/strong&gt; instabat&#xA;curaque arma saxea, naturaeque pondere quaeque aer!&lt;/p&gt;&#xA;&lt;ol&gt;&#xA;&lt;li&gt;Agros apertum aliis dominaeque rapidus&lt;/li&gt;&#xA;&lt;li&gt;Prima nulla est&lt;/li&gt;&#xA;&lt;li&gt;Hortatibus voto&lt;/li&gt;&#xA;&lt;/ol&gt;&#xA;&lt;h2 id=&#34;anum-istis-praefertur-est&#34;&gt;Anum istis praefertur est&lt;/h2&gt;&#xA;&lt;p&gt;Quaque coeptis lumina mea nuda dentes semine agitavit, caesique voluptas. Proque&#xA;priori vultus est colle fuit manet manibusque Liber vulnus famulosque memorante&#xA;dari. Aut quod ergo, oris simulasse. Ministros cogeret momordit aut tibi, posita&#xA;non inhaesit sede vulnera sontes Phoebeos, faenilibus non rursus.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/approach/</link>
+				<pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/approach/</guid>
+				<description>&lt;h1 id=&#34;et-malis-vellet-tellus-deseruere-in-credant&#34;&gt;Et malis vellet tellus deseruere in credant&lt;/h1&gt;&#xA;&lt;h2 id=&#34;inde-sidera-moenia-lacertis-nomen-nostra-membra&#34;&gt;Inde sidera moenia lacertis nomen nostra membra&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum miranti. Sonus faciunt omnibus frustra: illa possem ad regio&#xA;Anubis tamen. Sustulerat debent fluviis herbis attollere rogus et formae&#xA;nitentem avellere motis clipeus Achilles felix videam undas. &lt;em&gt;Posuit haec ipse&lt;/em&gt;&#xA;posse.&lt;/p&gt;&#xA;&lt;p&gt;Ore fame mons Olympi tantae &lt;em&gt;stringit&lt;/em&gt; columbas proxima habebat, longius alta&#xA;non. Haeserat gerunt detinuit genis est huc, dixit tam dumque nitidum.&lt;/p&gt;&#xA;&lt;ol&gt;&#xA;&lt;li&gt;Cristata causam Triones moenia habentem subito utentem&lt;/li&gt;&#xA;&lt;li&gt;Astraea castris contentus nisi leve eum invia&lt;/li&gt;&#xA;&lt;li&gt;Inferiusque capta cognoscenda flaventi locuta notavi fallere&lt;/li&gt;&#xA;&lt;li&gt;Moriens scripsi ictus tuo cum&lt;/li&gt;&#xA;&lt;/ol&gt;&#xA;&lt;p&gt;Tarpeias insurgens summo sinistra vertice, in neve utroque exempla Cyparissus&#xA;tanta tecti terras. Dextras superest flammis accipe volatu vulneris indomitae&#xA;unguibus insignia tempora aquas.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/auditor/allan_dewey/</link>
+				<pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/allan_dewey/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/mission/</link>
+				<pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/mission/</guid>
+				<description>&lt;h1 id=&#34;auras-queritur-facientes-dixit-venti-sustinui&#34;&gt;Auras queritur facientes dixit venti sustinui&lt;/h1&gt;&#xA;&lt;h2 id=&#34;e-in-mora&#34;&gt;E in mora&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum poenaque nuper destituit silendo quoniam, nec ait consorte&#xA;membra, figuram hanc cum. Manifesta vitae facies exiguumque iunctam dictis.&#xA;Vidit eadem, hanc cum descendit &lt;strong&gt;sinu&lt;/strong&gt; misit quem fecit, positisque pastorve.&#xA;Missus solos &lt;em&gt;potentia in&lt;/em&gt; erant noctem est!&lt;/p&gt;&#xA;&lt;pre&gt;&lt;code&gt;if (dvdProcessorVolume &amp;lt; mpegProcess(slashdot, gigahertz)) {&#xA;    transferAnsiBotnet.and(logSoftware, hsfClipboardSubnet.queue_publishing(&#xA;            systemMemory, 5, yahoo));&#xA;} else {&#xA;    swappableIpv -= spoolingAdwareCrossplatform;&#xA;    extranetAppArchitecture(1, dtd_rpc_font(45, 67, development_sli));&#xA;}&#xA;antivirus_ipv = touchscreenFiosGrep.portIcsDrive(zone_vista);&#xA;bootExpression = 2 * sprite_dv + apache;&#xA;if (cifsZone(status) &amp;gt; wddm_cifs) {&#xA;    disk_access_www.halftone_plagiarism = 4;&#xA;} else {&#xA;    domainFat(vectorCdnMalware, -2, hard.smartphone_e_wep(phreaking_memory,&#xA;            5, kerningError));&#xA;    address += troubleshooting;&#xA;    rdramRegistry(printerHoc);&#xA;}&#xA;&lt;/code&gt;&lt;/pre&gt;&#xA;&lt;p&gt;Ipsa namque impetus crinem nefandas, parant inmensum noviens specie vita. Ire&#xA;locus quietis, amata occiderat Achaidas cervum quos pavit dissiluit an&#xA;&lt;a href=&#34;http://artenitido.org/non.html&#34;&gt;loqui&lt;/a&gt; consolantia fontes; &lt;em&gt;tenus quae&lt;/em&gt;. Facit&#xA;verumque per Pindusque paelice inmensi: vino exire, fuisse munera. Quam pars&#xA;quod gravidi pennas: non illa et senex, et Iunone.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title></title>
+				<link>https://aiea-lab.github.io/vacancy/vacancy1/</link>
+				<pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/vacancy/vacancy1/</guid>
+				<description>&lt;p&gt;You can write $\LaTeX$ and &lt;em&gt;Markdown&lt;/em&gt; here.&lt;/p&gt;&#xA;&lt;h1 id=&#34;minyae-adgnoscitque-fugiebat-parentis-ausum-superos-huius&#34;&gt;Minyae adgnoscitque fugiebat parentis ausum superos huius&lt;/h1&gt;&#xA;&lt;h2 id=&#34;ait-erili-meruisse-iactatis-omnibus-erat&#34;&gt;Ait erili meruisse iactatis omnibus erat&lt;/h2&gt;&#xA;&lt;p&gt;Lorem markdownum natis, ipsi ipsi aut relictus saxo comitantibus aegro amori&#xA;verba fugisse &lt;strong&gt;mira mortisque leones&lt;/strong&gt;! Prior sui liquidissimus leve&#xA;properandum totidem studio, refert &lt;em&gt;magno&lt;/em&gt;, me quibus. Sternitur discordia&#xA;summaque, si deus in undam et vulnere dirusque est felices pallam miserere&#xA;curvamine comites. Tegumenque decipit suis, poscitur una dea sumus adnuerant,&#xA;gerebat est edam plura. Armigerae Cyllenius freti vaga adeunda, rura undas,&#xA;equarum ubi non laetoque pice.&lt;/p&gt;</description>
+			</item>
+			<item>
+				<title>Masters</title>
+				<link>https://aiea-lab.github.io/auditor/suvalavala/</link>
+				<pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/auditor/suvalavala/</guid>
+				<description></description>
+			</item>
+			<item>
+				<title>Research</title>
+				<link>https://aiea-lab.github.io/research/</link>
+				<pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+				<guid>https://aiea-lab.github.io/research/</guid>
+				<description>&lt;p&gt;Learn more about our &lt;a href=&#34;https://aiea-lab.github.io/project/&#34;&gt;active projects&lt;/a&gt; and if you are interested, see about &lt;a href=&#34;https://aiea-lab.github.io/join/&#34;&gt;joining us&lt;/a&gt;.&lt;/p&gt;&#xA;&lt;p&gt;Coming soon!&lt;/p&gt;&#xA;&lt;h1 id=&#34;funding&#34;&gt;Funding&lt;/h1&gt;&#xA;&lt;p&gt;Our research is generously supported by the Underwriters Labatory (subaward from Northwestern University), UC Santa Cruz Seed Funding, Department of Transportation, and Siemens.&lt;/p&gt;&#xA;&lt;!--# Modo est&#xA;&#xA;## Non sub haedum tenet&#xA;&#xA;Lorem markdownum esse diversa quoque vocavit, quam! Vires tibi axis dum spolium&#xA;*vaticinor fulminis*, a dixere attrahit generisque tamen?&#xA;&#xA;- Petit invergens iram praetendat iam&#xA;- Mecum res curva iunctura silvis hoc leonum&#xA;- Iacent gemitum quos&#xA;&#xA;## Non est duram mitis sonat proculcat tumulos&#xA;&#xA;Alce bimembres Dauni, cur ex voces referam adunco in sors. Manibusque poples&#xA;prodidit lata tantum quem suos ratae Aeginae sederunt degenerat Bacchus&#xA;descendere, patriisque ieiunia.&#xA;&#xA;## Harenas sanguine pennas fui&#xA;&#xA;Gentes aeris, sua mors dictis torvo colorem regione fugit principio Panopeusque&#xA;regni florentis vidisse. [Profusis](http://motu-tutus.io/exerceor-vestigia.php)&#xA;unda regnat ultima habitus cava tympana sudem et Aesonides fecit. Pondere visa&#xA;stant comitavit, et parente umida contentis divumque *sospes non* facinus arma&#xA;sed quamvis vectus. Fera nec uno erat, poterat censu nitebat, cognita simulacra?&#xA;Fumis patuisset tantum et tanta ad matris enodisque vestros exigui.&#xA;&#xA;&gt; Tamen coniectum sumpserat comites dura, amore exanimes iussit At? Cuncta&#xA;&gt; tellus ad turbine lupos. Querentes Ulixes rivus Thetis fraternaque adimunt,&#xA;&gt; sex vivacem, excepit potuit meruique, at tutos.&#xA;&#xA;## Diversaque Medusae probatur sequens&#xA;&#xA;Ea pruinosas verba lapidem, sustulit. Una quicquam nymphis adultera&#xA;[maturus](http://www.corripuere.net/toto) fuimusve lumina occidimus subiti&#xA;demoliturque pelagi.&#xA;&#xA;Satis omni hunc et quondam non, non curat adlabimur? Vocem oves curvum aptumque.&#xA;Addendum tamen; parensque multi locum palmas tenent dubites sacra! Autem de quem&#xA;autumnum cornu Echione Esse colebatur quodsi dextera perdidit rescierit coniuge,&#xA;conata, manent omnia. Illa est fecerat nubila vix semel tetigere sit sine&#xA;inguina.&#xA;--&gt;</description>
+			</item>
+	</channel>
 </rss>

--- a/docs/member/index.html
+++ b/docs/member/index.html
@@ -756,26 +756,6 @@
     
             <div class="row member-info">
     <div class="col-md-3">
-        <a href="https://aiea-lab.github.io/member/jonathan_m/">
-            <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/jonathan_m.jpg');"></div>
-        </a>
-        <div class="portrait-title">
-            <h3 itemprop="name"><a href="https://aiea-lab.github.io/member/jonathan_m/">Jonathan Morris</a></h3>
-        </div>
-    </div>
-
-    <div class="col-md-9">
-        
-            <h4>Undergrad Student, UC Santa Cruz</h4>
-            
-        
-    </div>
-
-</div>
-
-    
-            <div class="row member-info">
-    <div class="col-md-3">
         <a href="https://aiea-lab.github.io/member/vishrut_s/">
             <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/vishrut_s.jpg');"></div>
         </a>
@@ -976,6 +956,26 @@
     
             <div class="row member-info">
     <div class="col-md-3">
+        <a href="https://aiea-lab.github.io/member/jonathan_m/">
+            <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/jonathan_m.jpg');"></div>
+        </a>
+        <div class="portrait-title">
+            <h3 itemprop="name"><a href="https://aiea-lab.github.io/member/jonathan_m/">Jonathan Morris</a></h3>
+        </div>
+    </div>
+
+    <div class="col-md-9">
+        
+            <h4>Masters Student, UC Santa Cruz</h4>
+            
+        Researching Neuro-Symbolic AI. Interested in Scientific Discovery.
+    </div>
+
+</div>
+
+    
+            <div class="row member-info">
+    <div class="col-md-3">
         <a href="https://aiea-lab.github.io/member/shreyan/">
             <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/shreyan.png');"></div>
         </a>
@@ -1002,6 +1002,266 @@
   <h1>Auditors</h1>
   <p>Auditors are incoming AIEA lab students that work in the lab for
   credit for a quarter (10 weeks).</p>
+
+  
+    <h2>Auditor Hall of Fame</h2>
+    <p>
+      Each quarter, 1-2 outstanding auditing students are inducted into the
+      AIEA Lab Auditor Hall of Fame in recognition of their engagement,
+      contributions, and curiosity.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Quarter</th>
+          <th>Inductee</th>
+          <th>Recognition</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+          <tr>
+            <td>Fall 2025</td>
+            <td>First Last</td>
+            <td>Inducted into the Auditor Hall of Fame.</td>
+          </tr>
+        
+          <tr>
+            <td>Fall 2025</td>
+            <td>First Last</td>
+            <td>Inducted into the Auditor Hall of Fame.</td>
+          </tr>
+        
+      </tbody>
+    </table>
+  
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/default.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Lucy Han<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/shefali.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Shefali Gokarn<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/bhoomika.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Bhoomika Gupta<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/surya_raja.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Surya Raja<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/sanya_b.jpeg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Sanya Bhatia<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/tanvibelli.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Tanvi Belli Belli<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/ruhan.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Ruhan Gianchandani<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/Haatim_Ali.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Haatim Ali<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img/portraits/Bowie_C.JPG');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Bowie Chiu<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/Samanyu%20Headshot.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Samanyu Kumar<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/alexander_smolyanskiy.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Alexander Smolyanskiy<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img/portraits/anthony_f.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Anthony France<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/daniel_d.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Daniel Dubiner<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/dylan_price.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Dylan Price<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/Utkarsh_B.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Utkarsh Banka<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
   
         <div class="col-xs-12 col-md-3">
     <div id="profile">
@@ -1010,6 +1270,171 @@
             <h3 itemprop="name">
                 
                 Ran Chen<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/daniel_hong.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Daniel Hong<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/default.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Prateek Gupta<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/abhyuthoppae.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Abhyudita Thoppae<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/AryanBhatia.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Aryan Bhatia<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/ember.JPG');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Ember Lu<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/hyerin.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Hyerin Chung<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/naga_g.JPG');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Naga Gunukula<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/LarsVoigtBui.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Lars Voigt-Bui<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/caitelyn.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Caitelyn Huang<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/navaneeth.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Navaneeth Dontuboyina<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/default.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Mayank Narla<br/>
                 
             </h3>
         </div>
@@ -1115,21 +1540,6 @@
             <h3 itemprop="name">
                 
                 Chanchal Mukeshsingh<br/>
-                
-            </h3>
-        </div>
-
-    </div>
-</div>
-
-  
-        <div class="col-xs-12 col-md-3">
-    <div id="profile">
-        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/Haatim_Ali.jpg');"></div>
-        <div class="portrait-title">
-            <h3 itemprop="name">
-                
-                Haatim Ali<br/>
                 
             </h3>
         </div>
@@ -1265,6 +1675,21 @@
             <h3 itemprop="name">
                 
                 Vseslav Kazakov<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/default.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Mandy Wu<br/>
                 
             </h3>
         </div>
@@ -1530,6 +1955,21 @@
   
         <div class="col-xs-12 col-md-3">
     <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/riya-narang.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Riya Narang<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
         <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/tora_m.jpg');"></div>
         <div class="portrait-title">
             <h3 itemprop="name">
@@ -1725,6 +2165,21 @@
   
         <div class="col-xs-12 col-md-3">
     <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/pujitha.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Pujitha Samudrala<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
         <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/trisha.png');"></div>
         <div class="portrait-title">
             <h3 itemprop="name">
@@ -1890,6 +2345,36 @@
   
         <div class="col-xs-12 col-md-3">
     <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img/');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Pavithra Selvaraj<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/sameera_sk.png');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Sameera Sudarshan Kashyap<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
         <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/divya.jpg');"></div>
         <div class="portrait-title">
             <h3 itemprop="name">
@@ -2000,6 +2485,21 @@
             <h3 itemprop="name">
                 
                 Chris Camberos<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/suhani.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                suhani agarwal<br/>
                 
             </h3>
         </div>
@@ -3225,6 +3725,21 @@
   
         <div class="col-xs-12 col-md-3">
     <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/daniel_r.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Daniel Jean-Soo Rhee<br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
         <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/shaan.jpg');"></div>
         <div class="portrait-title">
             <h3 itemprop="name">
@@ -3260,6 +3775,21 @@
             <h3 itemprop="name">
                 
                 <br/>
+                
+            </h3>
+        </div>
+
+    </div>
+</div>
+
+  
+        <div class="col-xs-12 col-md-3">
+    <div id="profile">
+        <div class="small-portrait" itemprop="image" style="background-image: url('https://aiea-lab.github.io//img//portraits/default.jpg');"></div>
+        <div class="portrait-title">
+            <h3 itemprop="name">
+                
+                Suryakiran Valavala<br/>
                 
             </h3>
         </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,15 +1,94 @@
+
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://aiea-lab.github.io/</loc>
-    <lastmod>2026-03-31T00:00:00+00:00</lastmod>
+    <lastmod>2026-05-15T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/</loc>
+    <lastmod>2026-05-15T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/lucy_h/</loc>
+    <lastmod>2026-05-15T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/shefali/</loc>
+    <lastmod>2026-05-01T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/bhoomika/</loc>
+    <lastmod>2026-04-06T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/surya_raja/</loc>
+    <lastmod>2026-04-03T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/sanya_b/</loc>
+    <lastmod>2026-04-03T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/tanvibellibelli/</loc>
+    <lastmod>2026-04-03T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/ruhan_gianchandani/</loc>
+    <lastmod>2026-04-02T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/haatim_ali/</loc>
+    <lastmod>2026-04-01T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/bowie_c/</loc>
+    <lastmod>2026-04-01T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/samanyukumar/</loc>
+    <lastmod>2026-03-31T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/alexander_smolyanskiy/</loc>
+    <lastmod>2026-03-31T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/anthony/</loc>
+    <lastmod>2026-03-31T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/daniel_dubiner/</loc>
+    <lastmod>2026-03-31T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/dylan_price/</loc>
+    <lastmod>2026-03-31T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/utkarshbanka/</loc>
     <lastmod>2026-03-31T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/ran_chen/</loc>
     <lastmod>2026-03-31T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/daniel_hong/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/prateek_gupta/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/abhyuthoppae/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/aryanbhatia/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/ember_lu/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/hyerin/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/naga/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/larsvoigt-bui/</loc>
+    <lastmod>2026-03-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/caitelyn/</loc>
+    <lastmod>2026-03-29T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/navaneeth/</loc>
+    <lastmod>2026-03-20T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/mayank/</loc>
+    <lastmod>2026-02-04T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/adithi/</loc>
     <lastmod>2026-01-23T00:00:00+00:00</lastmod>
@@ -31,9 +110,6 @@
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/chanchal/</loc>
     <lastmod>2026-01-10T00:00:00+00:00</lastmod>
-  </url><url>
-    <loc>https://aiea-lab.github.io/auditor/haatim_ali/</loc>
-    <lastmod>2026-01-09T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/ron/</loc>
     <lastmod>2026-01-08T00:00:00+00:00</lastmod>
@@ -60,6 +136,9 @@
     <lastmod>2026-01-06T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/vseslav/</loc>
+    <lastmod>2026-01-05T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/mandy_wu/</loc>
     <lastmod>2026-01-05T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/anurag_n/</loc>
@@ -98,6 +177,15 @@
     <loc>https://aiea-lab.github.io/auditor/george/</loc>
     <lastmod>2026-01-05T00:00:00+00:00</lastmod>
   </url><url>
+    <loc>https://aiea-lab.github.io/publication/guaranteed-optimal-compositional-explanations-2025/</loc>
+    <lastmod>2025-11-25T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/publication/open-vocabulary-compositional-explanations-2025/</loc>
+    <lastmod>2025-11-25T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/publication/</loc>
+    <lastmod>2025-11-25T00:00:00+00:00</lastmod>
+  </url><url>
     <loc>https://aiea-lab.github.io/member/nazanin/</loc>
     <lastmod>2025-11-09T00:00:00+00:00</lastmod>
   </url><url>
@@ -122,8 +210,8 @@
     <loc>https://aiea-lab.github.io/publication/follow-my-lead-logical-fallacy-classification-with-knowledge-augmented-llms-2025/</loc>
     <lastmod>2025-10-11T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>https://aiea-lab.github.io/publication/</loc>
-    <lastmod>2025-10-11T00:00:00+00:00</lastmod>
+    <loc>https://aiea-lab.github.io/auditor/riya-narang/</loc>
+    <lastmod>2025-10-10T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/tora_m/</loc>
     <lastmod>2025-10-10T00:00:00+00:00</lastmod>
@@ -168,6 +256,9 @@
     <lastmod>2025-09-30T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/jaisree/</loc>
+    <lastmod>2025-09-30T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/pujitha/</loc>
     <lastmod>2025-09-30T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/trisha_moorkoth/</loc>
@@ -215,6 +306,12 @@
     <loc>https://aiea-lab.github.io/auditor/stanley/</loc>
     <lastmod>2025-07-10T00:00:00+00:00</lastmod>
   </url><url>
+    <loc>https://aiea-lab.github.io/auditor/pavithra/</loc>
+    <lastmod>2025-05-08T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/sameera_sk/</loc>
+    <lastmod>2025-04-08T00:00:00+00:00</lastmod>
+  </url><url>
     <loc>https://aiea-lab.github.io/auditor/divya_j/</loc>
     <lastmod>2025-04-03T00:00:00+00:00</lastmod>
   </url><url>
@@ -243,6 +340,9 @@
     <lastmod>2025-03-31T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/chris_camberos/</loc>
+    <lastmod>2025-03-31T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/suhani/</loc>
     <lastmod>2025-03-31T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/neha_h/</loc>
@@ -540,9 +640,6 @@
     <lastmod>2024-09-14T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/member/ashwin_n/</loc>
-    <lastmod>2024-09-14T00:00:00+00:00</lastmod>
-  </url><url>
-    <loc>https://aiea-lab.github.io/member/jonathan_m/</loc>
     <lastmod>2024-09-14T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/alumni/ameyaa_b/</loc>
@@ -1034,11 +1131,17 @@
     <loc>https://aiea-lab.github.io/alumni/nikhil/</loc>
     <lastmod>2024-05-13T00:00:00+00:00</lastmod>
   </url><url>
+    <loc>https://aiea-lab.github.io/auditor/daniel_r/</loc>
+    <lastmod>2024-03-31T00:00:00+00:00</lastmod>
+  </url><url>
     <loc>https://aiea-lab.github.io/publication/towards-a-fuller-understanding-of-neurons-with-clustered-compositional-explanations-2023/</loc>
     <lastmod>2023-12-15T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/alumni/rangasri/</loc>
     <lastmod>2023-12-01T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://aiea-lab.github.io/member/jonathan_m/</loc>
+    <lastmod>2023-11-08T00:00:00+00:00</lastmod>
   </url><url>
     <loc>https://aiea-lab.github.io/member/oliverchang/</loc>
     <lastmod>2023-10-27T00:00:00+00:00</lastmod>
@@ -1142,6 +1245,9 @@
     <loc>https://aiea-lab.github.io/join/deeplearning/</loc>
     <lastmod>2016-07-12T16:10:22+02:00</lastmod>
   </url><url>
+    <loc>https://aiea-lab.github.io/join/</loc>
+    <lastmod>2016-07-12T16:10:22+02:00</lastmod>
+  </url><url>
     <loc>https://aiea-lab.github.io/join/widelearning/</loc>
     <lastmod>2016-07-12T16:10:22+02:00</lastmod>
   </url><url>
@@ -1151,13 +1257,13 @@
   </url><url>
     <loc>https://aiea-lab.github.io/auditor/allan_dewey/</loc>
   </url><url>
-    <loc>https://aiea-lab.github.io/join/</loc>
-  </url><url>
     <loc>https://aiea-lab.github.io/mission/</loc>
   </url><url>
     <loc>https://aiea-lab.github.io/vacancy/vacancy1/</loc>
   </url><url>
     <loc>https://aiea-lab.github.io/categories/</loc>
+  </url><url>
+    <loc>https://aiea-lab.github.io/auditor/suvalavala/</loc>
   </url><url>
     <loc>https://aiea-lab.github.io/research/</loc>
   </url><url>

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>Tags on AIEA Lab</title>
-    <link>https://aiea-lab.github.io/tags/</link>
-    <description>Recent content in Tags on AIEA Lab</description>
-    <generator>Hugo</generator>
-    <language>en</language>
-    <copyright>&amp;copy; AIEA Lab, 2023 </copyright>
-    <atom:link href="https://aiea-lab.github.io/tags/index.xml" rel="self" type="application/rss+xml" />
-  </channel>
+	<channel>
+		<title>Tags on AIEA Lab</title>
+		<link>https://aiea-lab.github.io/tags/</link>
+		<description>Recent content in Tags on AIEA Lab</description>
+		<generator>Hugo</generator>
+		<language>en</language>
+		
+		
+		
+			<copyright>&amp;copy; AIEA Lab, 2023 </copyright>
+		
+		
+			<atom:link href="https://aiea-lab.github.io/tags/index.xml" rel="self" type="application/rss+xml" />
+	</channel>
 </rss>

--- a/themes/our-theme/layouts/section/member.html
+++ b/themes/our-theme/layouts/section/member.html
@@ -14,6 +14,35 @@
   <h1>Auditors</h1>
   <p>Auditors are incoming AIEA lab students that work in the lab for
   credit for a quarter (10 weeks).</p>
+
+  {{ with hugo.Data.auditor_hall_of_fame.entries }}
+    <h2>Auditor Hall of Fame</h2>
+    <p>
+      Each quarter, 1-2 outstanding auditing students are inducted into the
+      AIEA Lab Auditor Hall of Fame in recognition of their engagement,
+      contributions, and curiosity.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Quarter</th>
+          <th>Inductee</th>
+          <th>Recognition</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range . }}
+          <tr>
+            <td>{{ .quarter }}</td>
+            <td>{{ .name }}</td>
+            <td>{{ .recognition }}</td>
+          </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  {{ end }}
+
   {{ range where .Site.RegularPages "Section" "auditor" }}
         {{ partial "auditor_li" . }}
   {{ end }}

--- a/themes/our-theme/layouts/section/member.html
+++ b/themes/our-theme/layouts/section/member.html
@@ -15,7 +15,7 @@
   <p>Auditors are incoming AIEA lab students that work in the lab for
   credit for a quarter (10 weeks).</p>
 
-  {{ with hugo.Data.auditor_hall_of_fame.entries }}
+  {{ with .Site.Data.auditor_hall_of_fame.entries }}
     <h2>Auditor Hall of Fame</h2>
     <p>
       Each quarter, 1-2 outstanding auditing students are inducted into the


### PR DESCRIPTION
This pull request adds an Auditor Hall of Fame section to the website.

Changes include:
- Added Hall of Fame inductee data under `data/auditor_hall_of_fame.yaml`
- Updated the member page layout to display Hall of Fame inductees in the Auditors section
- Rebuilt the generated site under `docs/`
